### PR TITLE
Rename the camera backend to a gphoto2 backend

### DIFF
--- a/services/imagery/Dockerfile
+++ b/services/imagery/Dockerfile
@@ -45,13 +45,13 @@ RUN export NODE_ENV=production && npm install
 # Adding in the output from the js builder above.
 COPY --from=builder /builder/lib lib
 
-# Must be one of "camera", "file", "sync".
-ENV BACKEND='camera' \
+# Must be one of "gphoto2", "file", "sync".
+ENV BACKEND='gphoto2' \
     # Must be set if using the sync backend.
     IMAGERY_SYNC_URL='' \
-    # Can be set when using the camera backend.
+    # Can be set when using the gphoto2 backend.
     TELEMETRY_URL='' \
-    # Interval to trigger camera images at in the camera backend.
+    # Interval to trigger gphoto2 images at in the gphoto2 backend.
     # Defaults to 2 seconds.
     CAPTURE_INTERVAL='2'
 

--- a/services/imagery/README.md
+++ b/services/imagery/README.md
@@ -4,7 +4,7 @@ Service that hosts either gathers images or repeats imagery data.
 
 The service has three backends which can be used:
 
-- `camera` (default)
+- `gphoto2` (default)
 
   This backend takes images directly from a camera device passed in to the
   container. Running as priviledged will do this if it's hard to find which
@@ -33,10 +33,10 @@ Note that no telemetry data is gathered for images at the current time.
 
 ## Running the Image
 
-The `BACKEND` environment variable should be set to one of `camera`, `file`, or
-`sync`.
+The `BACKEND` environment variable should be set to one of `gphoto2`, `file`,
+or `sync`.
 
-If using `camera`, the `CAPTURE_INTERVAL` environment variable can be set to
+If using `gphoto2`, the `CAPTURE_INTERVAL` environment variable can be set to
 set the rate at which images are taken in seconds. This defaults to every two
 seconds. To add telemetry to images, set the `TELEMETRY_URL` environment
 variable. Without this, the image metadata will not contain any camera
@@ -51,13 +51,13 @@ to go to (`/opt/new-images`).
 To see and access the images registered, you can mount the the imagery
 directory on the host (`/opt/imagery`).
 
-Here's an example of using the camera backend (camera required to use) and
+Here's an example of using the `gphoto2` backend (camera required to use) and
 mounting the imagery directory on the host computer:
 
 ```
 $ docker run -it -p 8081:8081 \
     --privileged
-    -e BACKEND=camera
+    -e BACKEND=gphoto2
     -e CAPTURE_INTERVAL=2.5
     -e TELEMETRY_URL=192.168.0.4:5000
     -v '$HOME/Desktop/imagery:/opt/imagery'

--- a/services/imagery/src/backends/gphoto2-backend.js
+++ b/services/imagery/src/backends/gphoto2-backend.js
@@ -5,8 +5,8 @@ import { imagery, telemetry } from '../messages';
 
 import { removeExif, wait } from '../util';
 
-export default class CameraBackend {
-    /** Create a new camera backend. */
+export default class GPhoto2Backend {
+    /** Create a new gphoto2 backend. */
     constructor(imageStore, interval, telemUrl) {
         this._imageStore = imageStore;
         this._interval = interval;

--- a/services/imagery/src/service.js
+++ b/services/imagery/src/service.js
@@ -1,10 +1,10 @@
 import { createApp } from './app';
-import CameraBackend from './backends/camera-backend';
+import GPhoto2Backend from './backends/gphoto2-backend';
 import FileBackend from './backends/file-backend';
 import SyncBackend from './backends/sync-backend';
 import ImageStore from './image-store';
 
-const BACKENDS = ['camera', 'file', 'sync'];
+const BACKENDS = ['gphoto2', 'file', 'sync'];
 
 export default class Service {
     /**
@@ -14,7 +14,7 @@ export default class Service {
      *
      * @param {Object}  options
      * @param {number}  options.port
-     * @param {string}  options.backend           - one of 'camera',
+     * @param {string}  options.backend           - one of 'gphoto2',
      *                                              'file', 'sync'
      * @param {string}  [options.imagerySyncUrl]  - url to sync
      *                                              imagery against
@@ -23,7 +23,7 @@ export default class Service {
      * @param {boolean} [options.printNew=false]  - prints when a new
      *                                              image is added
      * @param {number}  [options.captureInterval] - capture interval
-     *                                              for the camera
+     *                                              for the gphoto2
      *                                              backend
      */
     constructor(options) {
@@ -60,8 +60,8 @@ export default class Service {
         let backend;
 
         switch (this._backend) {
-            case 'camera':
-                backend = new CameraBackend(
+            case 'gphoto2':
+                backend = new GPhoto2Backend(
                     imageStore, this._captureInterval, this._telemUrl
                 );
                 break;


### PR DESCRIPTION
This allows for multiple camera backends to exist if need be, and clears up naming confusion down the road.

There are not any unit tests configured for the imagery service, so to test it out I had to just comment out the body of `GPhoto2Backend._takePhoto` and `GPhoto2Backend._getCamera` and put a log in the middle to verify that the loop was running.