### PR TITLE
Freeze the interop server on the `2018.09` tag

### DIFF
--- a/services/interop-proxy/test.sh
+++ b/services/interop-proxy/test.sh
@@ -15,7 +15,8 @@ start_interop_server() {
     printf "\033[33mStarting interop server..." 1>&2
 
     docker run -itd --rm --net=interop-proxy-test-net --ip=172.37.0.2 \
-            -p 8081:80 --name interop-proxy-test auvsisuas/interop-server \
+            -p 8081:80 --name interop-proxy-test \
+            auvsisuas/interop-server:2018.09 \
             > /dev/null
 
     if [ "$?" -ne 0 ]; then

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         ipv4_address: 172.16.238.10
 
   interop-server:
-    image: auvsisuas/interop-server
+    image: auvsisuas/interop-server:2018.09
     ports:
       - '8080:80'
     networks:


### PR DESCRIPTION
This will prevent problems from happening in the future from when a
backwards-incompatible change is pushed to
`auvsisuas/interop-server:latest`.

Tagged deployments were added in auvsi-suas/interop#340.

After the end of October, the tag should be updated to `2018.10` and
interop-proxy should be modified (if needed) to work with it.