### PR TITLE
Add constraint to pymavlink to fix mavproxy service builds

### DIFF
--- a/services/mavproxy/Dockerfile
+++ b/services/mavproxy/Dockerfile
@@ -16,7 +16,7 @@ RUN apk --no-cache add \
 # https://github.com/gmyoungblood-parc/docker-alpine-ardupilot/blob/master/Dockerfile#L81
 RUN sed -i 's/, int,/, unsigned int,/' /usr/include/assert.h
 
-RUN pip install mavproxy
+RUN pip install 'pymavlink<=2.2.10' mavproxy
 
 # TODO: multi-stage
 


### PR DESCRIPTION
pymavlink version 2.2.11 does not build, and this mandates the version
to be <= 2.2.10.