### PR TITLE
Disable source-map-support for Jest to fix test error reporting

### DIFF
--- a/services/forward-interop/.babelrc
+++ b/services/forward-interop/.babelrc
@@ -1,8 +1,7 @@
 {
   "sourceMaps": "inline",
   "plugins": [
-    "add-module-exports",
-    "source-map-support"
+    "add-module-exports"
   ],
   "presets": [
     [
@@ -13,5 +12,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        "source-map-support"
+      ]
+    }
+  }
 }

--- a/services/pong/.babelrc
+++ b/services/pong/.babelrc
@@ -1,8 +1,7 @@
 {
   "sourceMaps": "inline",
   "plugins": [
-    "add-module-exports",
-    "source-map-support"
+    "add-module-exports"
   ],
   "presets": [
     [
@@ -13,5 +12,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        "source-map-support"
+      ]
+    }
+  }
 }

--- a/services/telemetry/.babelrc
+++ b/services/telemetry/.babelrc
@@ -1,8 +1,7 @@
 {
   "sourceMaps": "inline",
   "plugins": [
-    "add-module-exports",
-    "source-map-support"
+    "add-module-exports"
   ],
   "presets": [
     [
@@ -13,5 +12,12 @@
         }
       }
     ]
-  ]
+  ],
+  "env": {
+    "development": {
+      "plugins": [
+        "source-map-support"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
It seems like there was a conflict with the built-in source mapping somewhere in Jest and the source-map-support babel plugin. It was working fine with the service source code, but not for the test cases. The `.babelrc`s are now configured to only use the source-map-support plugin when building the source code, and is not including when running tests, since Jest takes care of this.