### PR TITLE
Telemetry queue folding

### DIFF
--- a/services/telemetry/test/service.test.js
+++ b/services/telemetry/test/service.test.js
@@ -116,7 +116,7 @@ test('download raw mission 2', async () => {
     .toHaveLength(rawMission2.mission_items.length);
 });
 
-test('download raw mission 2 concurrently', async () => {
+test('write barrier', async () => {
   let dl = async () => {
     let res = await request('http://localhost:5000')
       .get('/api/raw-mission')
@@ -127,8 +127,26 @@ test('download raw mission 2 concurrently', async () => {
       .toHaveLength(rawMission2.mission_items.length);
   };
 
+  let upload = async () => {
+    let res = await request('http://localhost:5000')
+      .post('/api/raw-mission')
+      .sendProto(telemetry.RawMission.create(rawMission3));
+
+    expect(res.status).toEqual(200);
+  };
+
+  let dl2 = async () => {
+    let res = await request('http://localhost:5000')
+      .get('/api/raw-mission')
+      .proto(telemetry.RawMission);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.mission_items)
+      .toHaveLength(rawMission3.mission_items.length);
+  };
+
   await Promise.all([
-    dl(), dl(), dl()
+    dl(), dl(), dl(), upload(), dl2(), dl2()
   ]);
 });
 

--- a/services/telemetry/test/service.test.js
+++ b/services/telemetry/test/service.test.js
@@ -116,6 +116,22 @@ test('download raw mission 2', async () => {
     .toHaveLength(rawMission2.mission_items.length);
 });
 
+test('download raw mission 2 concurrently', async () => {
+  let dl = async () => {
+    let res = await request('http://localhost:5000')
+      .get('/api/raw-mission')
+      .proto(telemetry.RawMission);
+
+    expect(res.status).toEqual(200);
+    expect(res.body.mission_items)
+      .toHaveLength(rawMission2.mission_items.length);
+  };
+
+  await Promise.all([
+    dl(), dl(), dl()
+  ]);
+});
+
 test('upload raw mission 3', async () => {
   let res = await request('http://localhost:5000')
     .post('/api/raw-mission')


### PR DESCRIPTION
Repeated requests to retrieve a mission will not make redundant entries in the queue - only one request will be made instead, and then the results of that request will be forwarded to all requesters. If a write request is placed on the queue, however, a write barrier is recognized, and therefore a new request to retrieve a mission will be placed on the queue.