### PR TITLE
Update interop server to november release

### DIFF
--- a/services/interop-proxy/lib/interop_proxy/request.ex
+++ b/services/interop-proxy/lib/interop_proxy/request.ex
@@ -14,7 +14,7 @@ defmodule InteropProxy.Request do
   Log in to the server and get a cookie.
   """
   def login(url, username, password) do
-    body = get_urlencoded %{username: username, password: password}
+    body = get_json %{username: username, password: password}
 
     "http://#{url}/api/login"
     |> HTTPoison.post(body, [@urlencoded])

--- a/services/interop-proxy/lib/interop_proxy/sanitize.ex
+++ b/services/interop-proxy/lib/interop_proxy/sanitize.ex
@@ -11,9 +11,7 @@ defmodule InteropProxy.Sanitize do
 
   # Aliasing the nested messages.
   alias InteropProxy.Message.Interop.InteropMission.FlyZone
-  alias InteropProxy.Message.Interop.Obstacles.{
-    StationaryObstacle, MovingObstacle
-  }
+  alias InteropProxy.Message.Interop.Obstacles.StationaryObstacle
 
   def sanitize_mission(nil) do
     %InteropMission{
@@ -51,9 +49,7 @@ defmodule InteropProxy.Sanitize do
     %Obstacles{
       time: time(),
       stationary: obstacles["stationary_obstacles"]
-                  |> sanitize_stationary_obstacles,    
-      moving: obstacles["moving_obstacles"]
-              |> sanitize_moving_obstacles
+                  |> sanitize_stationary_obstacles
     }
   end
 
@@ -64,16 +60,6 @@ defmodule InteropProxy.Sanitize do
         pos: obs |> sanitize_position,
         height: obs["cylinder_height"] |> meters,
         radius: obs["cylinder_radius"] |> meters
-      }
-    end)
-  end
-
-  defp sanitize_moving_obstacles(moving) do
-    moving
-    |> Enum.map(fn obs ->
-      %MovingObstacle{
-        pos: obs |> sanitize_aerial_position,
-        radius: obs["sphere_radius"] |> meters
       }
     end)
   end

--- a/services/interop-proxy/test.sh
+++ b/services/interop-proxy/test.sh
@@ -16,7 +16,7 @@ start_interop_server() {
 
     docker run -itd --rm --net=interop-proxy-test-net --ip=172.37.0.2 \
             -p 8081:80 --name interop-proxy-test \
-            auvsisuas/interop-server:2018.09 \
+            auvsisuas/interop-server:2018.11 \
             > /dev/null
 
     if [ "$?" -ne 0 ]; then

--- a/services/interop-proxy/test/interop_proxy/request_test.exs
+++ b/services/interop-proxy/test/interop_proxy/request_test.exs
@@ -28,32 +28,18 @@ defmodule InteropProxy.RequestTest do
     assert mission["active"] === true
   end
 
-  test "get moving and stationary obstacles" do
+  test "get stationary obstacles" do
     {:ok, _, cookie} = Request.login url(), username(), password()
 
     {:ok, obstacles_1} = Request.get_obstacles url(), cookie
 
-    # Should be two types of obstacles.
-    assert obstacles_1 |> Map.keys |> length === 2
+    # Should be one type of obstacles.
+    assert obstacles_1 |> Map.keys |> length === 1
 
-    mov_1  = obstacles_1["moving_obstacles"]
     stat_1 = obstacles_1["stationary_obstacles"]
 
-    # Both type of obstacles should have 4 keys.
-    assert mov_1 |> Enum.at(0) |> Map.keys |> length === 4
+    # Stationary obstacles should have 4 keys.
     assert stat_1 |> Enum.at(0) |> Map.keys |> length === 4
-
-    # Sleep a little and request again, the moving ones should have
-    # changed, but the stationary should be the same.
-    Process.sleep(100)
-
-    {:ok, obstacles_2} = Request.get_obstacles url(), cookie
-
-    mov_2  = obstacles_2["moving_obstacles"]
-    stat_2 = obstacles_2["stationary_obstacles"]
-
-    assert mov_1 !== mov_2
-    assert stat_1 === stat_2 
   end
 
   test "post valid telemetry" do

--- a/services/interop-proxy/test/interop_proxy_test.exs
+++ b/services/interop-proxy/test/interop_proxy_test.exs
@@ -16,13 +16,11 @@ defmodule InteropProxyTest do
     assert is_float(mission.home_pos.lat)
   end
 
-  test "get moving and stationary obstacles" do
+  test "get stationary obstacles" do
     obs = get_obstacles!()
 
     assert is_list(obs.stationary)
-    assert is_list(obs.moving)
 
-    assert is_float(Enum.at(obs.stationary, 0).pos.lat)
     assert is_float(Enum.at(obs.stationary, 0).pos.lat)
   end
 

--- a/services/interop-proxy/test/interop_proxy_web/controllers/obstacles_controller_test.exs
+++ b/services/interop-proxy/test/interop_proxy_web/controllers/obstacles_controller_test.exs
@@ -9,7 +9,6 @@ defmodule InteropProxyWeb.ObstaclesControllerTest do
     |> protobuf_response(Obstacles)
 
     assert is_list(response.stationary)
-    assert is_list(response.moving)
   end
 
   test "returns the current obstacles as JSON", %{conn: conn} do
@@ -19,7 +18,6 @@ defmodule InteropProxyWeb.ObstaclesControllerTest do
     |> json_response(200)
 
     assert is_list(response["stationary"])
-    assert is_list(response["moving"])
   end
 
   test "stationary obstacles have a height, but no altitude", %{conn: conn} do
@@ -30,17 +28,6 @@ defmodule InteropProxyWeb.ObstaclesControllerTest do
     Enum.each response.stationary, fn obs ->
       assert is_float(obs.height)
       refute Map.has_key?(obs.pos, :alt_msl)
-    end
-  end
-
-  test "moving obstacles have an altitude, but no height", %{conn: conn} do
-    response = conn
-    |> get(obstacles_path(conn, :index))
-    |> protobuf_response(Obstacles)
-
-    Enum.each response.moving, fn obs ->
-      assert is_float(obs.pos.alt_msl)
-      refute Map.has_key?(obs, :height)
     end
   end
 end

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         ipv4_address: 172.16.238.10
 
   interop-server:
-    image: auvsisuas/interop-server:2018.09
+    image: auvsisuas/interop-server:2018.11
     ports:
       - '8080:80'
     networks:


### PR DESCRIPTION
Moving obstacles were removed and thus references were removed from
interop-proxy. Note that they were not taken out of the protobuf, and so
would remain as a empty list. Also had to update the login request since
it uses JSON instead of a urlencoded body.