### PR TITLE
Return interop server status code on 4xx and 5xx

### DIFF
--- a/services/interop-proxy/lib/interop_proxy/request.ex
+++ b/services/interop-proxy/lib/interop_proxy/request.ex
@@ -198,9 +198,10 @@ defmodule InteropProxy.Request do
   defp handle_resp({:ok, %{status_code: 403}}, _type, _opts),
     do: {:error, :forbidden}
 
-  # If we have anything else, we'll return the body as the reason for
-  # an error.
-  defp handle_resp({:ok, %{body: body}}, _type, _opts), do: {:error, body}
+  # If we have anything else, we'll return the status code and body
+  # as the reason for an error.
+  defp handle_resp({:ok, resp}, _type, _opts),
+    do: {:error, {:message, resp.status_code, resp.body}}
 
   # Making a urlencoded message from a map.
   defp get_urlencoded(body) when is_map(body) do

--- a/services/interop-proxy/lib/interop_proxy_web/controllers/controller_helpers.ex
+++ b/services/interop-proxy/lib/interop_proxy_web/controllers/controller_helpers.ex
@@ -14,9 +14,14 @@ defmodule InteropProxyWeb.ControllerHelpers do
 
   def send_message(conn, _status_code, {:error, reason}) do
     {code, text} = case reason do
-      %HTTPoison.Error{} -> {503, "Interop server not available\n"}
-      :forbidden         -> {503, "Interop server did not accept cookie\n"}
-      other              -> {500, other}
+      %HTTPoison.Error{} ->
+        {503, "Interop server not available\n"}
+      :forbidden ->
+        {503, "Interop server did not accept cookie\n"}
+      {:message, code, message} when div(code, 100) < 4 ->
+        {500, "Unexpected interop status code #{code} with \"#{message}\""}
+      {:message, code, message} ->
+        {code, "Interop server: " <> message}
     end
 
     conn


### PR DESCRIPTION
Right now everything becomes a 500, and so if invalid data is sent, it looks like interop proxy had an error and that the client was correct when they were not. This fixes that by simply giving the status code and the message on the interop server.

If an unexpected 2xx or 3xx code is returned, this will give a 500 as before with a message explaining it.