### PR TITLE
Lift the proto path up a directory

### DIFF
--- a/services/common/messages/imagery.proto
+++ b/services/common/messages/imagery.proto
@@ -12,7 +12,7 @@
 
 syntax = "proto3";
 
-import "telemetry.proto";
+import "messages/telemetry.proto";
 
 package imagery;
 


### PR DESCRIPTION
This lifts the proto path up to the `services/common` folder instead of `services/common/messages`. This is for making Python proto imports work more naturally, instead of requiring all Python generated code to go into the global import namespace because they were not being contained into a single module. (The protobuf people insist on not allowing relative imports for Python generated code which causes this problem.)

The package names are still the same to minimize disruption, though it seems to be more conventional to have the package name match the import path more closely. The existing implementations in services now don't use the regular protobuf compiler and don't seem to be phased by this change.

If y'all know of a better way to make Python generated protobuf modules happy let me know, but since this is what the protobuf people are essentially recommending I think this works best even if the package names aren't matching. I can also add `messages.` in front of the package names though this will require changes in the services to accommodate.