### PR TITLE
Make the Travis config be more language-agnostic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-language: node_js
-node_js: '8'
+language: minimal
+dist: xenial
 sudo: required
 env:
   - COVERALLS_PARALLEL=true
 services:
   - docker
+install: true  # disabled
 script: ./ci/script.sh
 after_script: ./ci/after-script.sh
 jobs:
@@ -19,10 +20,20 @@ jobs:
     - env: SERVICE=dashboard
     - stage: test
       env: SERVICE_TEST=telemetry
+      language: node_js
+      node_js: '8'
     - env: SERVICE_TEST=interop-proxy
+      language: elixir
+      elixir: '1.6'
     - env: SERVICE_TEST=pong
+      language: node_js
+      node_js: '8'
     - env: SERVICE_TEST=forward-interop
+      language: node_js
+      node_js: '8'
     - env: SERVICE_TEST=imagery
+      language: node_js
+      node_js: '8'
 notifications:
   email: false
   webhooks:

--- a/ci/after-script.sh
+++ b/ci/after-script.sh
@@ -5,11 +5,16 @@
 # relative to the root directory of the test container (and should
 # start with "/test/..."), we have to replace this with the path of
 # the service.
-if [ -n "$SERVICE_TEST" ]; then
+
+handle_nodejs() {
   NODEJS_LCOV=services/"$SERVICE_TEST"/coverage/lcov.info
 
   if [ -f "$NODEJS_LCOV" ]; then
     sed "s,SF:/test/,SF:services/$SERVICE_TEST/," "$NODEJS_LCOV" |
       npx coveralls
   fi
+}
+
+if [ -n "$SERVICE_TEST" ]; then
+  [ -n "$TRAVIS_NODE_VERSION" ] && handle_nodejs
 fi


### PR DESCRIPTION
Also updated to Xenial to allow for Python 3.7 in the future.

Needed to disable install commands because of Elixir.