### PR TITLE
Update interop server to December release

### DIFF
--- a/services/interop-proxy/Dockerfile
+++ b/services/interop-proxy/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_BUILDER=elixir:1.6-alpine
-ARG BASE=alpine
+ARG BASE=alpine:3.8
 
 FROM ${BASE_BUILDER} as builder
 

--- a/services/interop-proxy/test.sh
+++ b/services/interop-proxy/test.sh
@@ -16,7 +16,7 @@ start_interop_server() {
 
     docker run -itd --rm --net=interop-proxy-test-net --ip=172.37.0.2 \
             -p 8081:80 --name interop-proxy-test \
-            auvsisuas/interop-server:2018.11 \
+            auvsisuas/interop-server:2018.12 \
             > /dev/null
 
     if [ "$?" -ne 0 ]; then

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         ipv4_address: 172.16.238.10
 
   interop-server:
-    image: auvsisuas/interop-server:2018.11
+    image: auvsisuas/interop-server:2018.12
     ports:
       - '8080:80'
     networks:


### PR DESCRIPTION
Nothing eventful happened on the API side for users, so no changes to interop proxy were needed. Note that there was not a Janurary release of the interop server since the last commit on GitHub was on December 2nd.