### PR TITLE
Constrain winston to version 3.1

### DIFF
--- a/services/common/nodejs/package.json
+++ b/services/common/nodejs/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "async": "^2.6.1",
     "chalk": "^2.4.1",
-    "winston": "^3.0.0"
+    "winston": "~3.1.0"
   }
 }


### PR DESCRIPTION
winston 3.2 was causing problems at the moment which do not need to be fixed yet. This fixes the build problems for now until the js services are compatible with winston >= 3.2.