### PR TITLE
Add functionality for submitting targets and processing images

### DIFF
--- a/services/common/messages/image_rec.proto
+++ b/services/common/messages/image_rec.proto
@@ -58,6 +58,20 @@ message PipelineState {
     repeated uint32 removed_targets = 19;
 }
 
+message PipelineImage {
+    // Time last updated.
+    double time = 1;
+    // Image id from imagery service.
+    uint32 id = 2;
+    // See PipelineState above for fields below. Not including
+    // processing lists.
+    bool processed_auto = 3;
+    bool errored_auto = 4;
+    bool skipped_auto = 5;
+    bool processed_manual = 6;
+    bool skipped_manual = 7;
+}
+
 message PipelineTarget {
     // Time last updated.
     double time = 1;

--- a/services/common/messages/image_rec.proto
+++ b/services/common/messages/image_rec.proto
@@ -37,7 +37,7 @@ message PipelineState {
     repeated uint32 skipped_manual = 11;
     // Current state of targets.
     //
-    // Targets are stored by id numbers starting at 0 and don't
+    // Targets are stored by id numbers starting at 1 and don't
     // necessarily correspond to interop target ids.
     //
     // - All targets contains all created at any point.
@@ -58,7 +58,7 @@ message PipelineState {
     repeated uint32 removed_targets = 19;
 }
 
-message Target {
+message PipelineTarget {
     // Time last updated.
     double time = 1;
     // Target id number given by the image rec pipeline.

--- a/services/image-rec-master/Dockerfile.test
+++ b/services/image-rec-master/Dockerfile.test
@@ -35,4 +35,5 @@ COPY image-rec-master/setup.cfg .
 
 ENV PYTHONUNBUFFERED=TRUE
 
-CMD pycodestyle service test && python -m pytest --cov=service test
+CMD pycodestyle service test && python -m pytest --cov=service test && \
+    coverage html -d coverage/html

--- a/services/image-rec-master/README.md
+++ b/services/image-rec-master/README.md
@@ -45,6 +45,39 @@ To get JSON data for the Protobuf endpoints, pass in `application/json` for the
   On successful response: `200` status code with `image_rec::Target` Protobuf
   message.
 
+- `POST /api/pipeline/targets`
+
+  Create a new target in the pipeline.
+
+  Note that the target will be queued for submission and will not be submitted
+  instantly. Only the `odlc` and `image_id` fields will be read from the body.
+
+  If an autonomous standard target is submitted which is similar to an existing
+  autonomous standard target, the target will not post and the request will
+  redirect.
+
+  Body should be an `image_rec::Target` Protobuf Message.
+
+  On successful response: `201` status code with `image_rec::Target` Protobuf
+  message.
+
+  On non-unique autonomous standard target: `303` status code with reference to
+  matching target.
+
+- `POST /api/pipeline/targets/:id/queue-removal`
+
+  Create a target for removal.
+
+  Note that the target will be queued for removal and will not be removed
+  instantly. If the image is already in the removal pipeline, it will return
+  a conflict. Once removed, the target will still exist for this service, but
+  will only be removed from the interop server.
+
+  On successful response: `204` status code with `image_rec::Target` Protobuf
+  message.
+
+  On conflict: `409` status code.
+
 - `POST /api/pipeline/reset`
 
   Completely reset the pipeline.

--- a/services/image-rec-master/README.md
+++ b/services/image-rec-master/README.md
@@ -35,6 +35,51 @@ To get JSON data for the Protobuf endpoints, pass in `application/json` for the
   On successful response: `200` status code with `image_rec::PipelineState`
   Protobuf message.
 
+- `GET /api/pipeline/images/:id`
+
+  Return an image by id in the pipeline.
+
+  `id` must be a valid integer id from the imagery service.
+
+  On successful response: `200` status code with `image_rec::PipelineImage`
+  Protobuf message.
+
+- `POST /api/pipeline/images/start-processing-next-auto`
+
+  Start the processing window for the next auto image.
+
+  The image is returned. Note that the processing must be finished or else the
+  image will be treated as errored after enough time as passed.
+
+  On successful response: `200` status code with `image_rec::PipelineImage`
+  Protobuf message.
+
+  If no image is available: `409` status code.
+
+- `POST /api/pipeline/images/:id/finish-processing-auto`
+
+  Mark the auto processing as finished for an image.
+
+  `id` must be a valid integer id of an image being processed. The image is
+  returned.
+
+  On successful response: `200` status code with `image_rec::PipelineImage`
+  Protobuf message.
+
+  If the image is not being processed: `409` status code.
+
+- `POST /api/pipeline/images/process-next-manual`
+
+  Process the next manual image.
+
+  The image is returned. Note that the processing is finished immediately and
+  will be shown in the image returned.
+
+  On successful response: `200` status code with `image_rec::PipelineImage`
+  Protobuf message.
+
+  If no image is available: `409` status code.
+
 - `GET /api/pipeline/targets/:id`
 
   Return a target by id in the pipeline.

--- a/services/image-rec-master/README.md
+++ b/services/image-rec-master/README.md
@@ -42,8 +42,8 @@ To get JSON data for the Protobuf endpoints, pass in `application/json` for the
   `id` must be a nonnegative integer. Note that this is not the same as
   the _Odlc_ `id` given by the Interop Server.
 
-  On successful response: `200` status code with `image_rec::Target` Protobuf
-  message.
+  On successful response: `200` status code with `image_rec::PipelineTarget`
+  Protobuf message.
 
 - `POST /api/pipeline/targets`
 

--- a/services/image-rec-master/README.md
+++ b/services/image-rec-master/README.md
@@ -101,10 +101,10 @@ To get JSON data for the Protobuf endpoints, pass in `application/json` for the
   autonomous standard target, the target will not post and the request will
   redirect.
 
-  Body should be an `image_rec::Target` Protobuf Message.
+  Body should be an `image_rec::PipelineTarget` Protobuf Message.
 
-  On successful response: `201` status code with `image_rec::Target` Protobuf
-  message.
+  On successful response: `201` status code with `image_rec::PipelineTarget`
+  Protobuf message.
 
   On non-unique autonomous standard target: `303` status code with reference to
   matching target.
@@ -118,8 +118,8 @@ To get JSON data for the Protobuf endpoints, pass in `application/json` for the
   a conflict. Once removed, the target will still exist for this service, but
   will only be removed from the interop server.
 
-  On successful response: `204` status code with `image_rec::Target` Protobuf
-  message.
+  On successful response: `204` status code with `image_rec::PipelineTarget`
+  Protobuf message.
 
   On conflict: `409` status code.
 

--- a/services/image-rec-master/service/app.py
+++ b/services/image-rec-master/service/app.py
@@ -102,14 +102,14 @@ async def handle_get_pipeline_target_by_id(request):
     if target:
         return _proto_response(request, target)
     else:
-        return web.Response(status=404)
+        return web.HTTPNotFound()
 
 
 @routes.post('/api/pipeline/reset')
 async def handle_reset_pipeline(request):
     """Empty out the current Redis database to reset the pipeline."""
     await request.app['redis'].flushdb()
-    return web.Response(status=204)
+    return web.HTTPNoContent()
 
 
 @routes.get('/api/pipeline/archive')
@@ -133,7 +133,7 @@ async def handle_get_pipeline_archive(request):
             'Content-Type': 'application/zip'
         })
     else:
-        return web.Response(status=204)
+        return web.HTTPNoContent()
 
 
 async def _get_target(request, target_id):

--- a/services/image-rec-master/service/app.py
+++ b/services/image-rec-master/service/app.py
@@ -5,7 +5,7 @@ from aiohttp import web
 import aioredis
 import google.protobuf.json_format
 
-from messages.image_rec_pb2 import PipelineState, Target
+from messages.image_rec_pb2 import PipelineState, PipelineTarget
 from messages.interop_pb2 import Odlc
 
 from .backup import create_archive
@@ -111,7 +111,7 @@ async def handle_post_pipeline_target(request):
     """Create a target from an odlc."""
     # Reading submitted target, we only care about the odlc and
     # source image.
-    target = await _parse_body(request, Target)
+    target = await _parse_body(request, PipelineTarget)
     odlc = target.odlc
     image_id = target.image_id
 
@@ -188,7 +188,7 @@ async def handle_post_pipeline_target(request):
     # fields manually instead of using incoming target in case
     # the caller added fields. Submitted / errored / removed
     # default to `False`.
-    ret_target = Target()
+    ret_target = PipelineTarget()
     ret_target.time = time()
     ret_target.id = target_id
     ret_target.odlc.CopyFrom(target.odlc)
@@ -280,7 +280,7 @@ async def _get_target(request, target_id):
     target_hash = await request.app['redis'].hgetall(f'target:{target_id}')
 
     if target_hash:
-        msg = Target()
+        msg = PipelineTarget()
         msg.time = time()
 
         msg.id = int(target_hash.get(b'id', b'0'))

--- a/services/image-rec-master/service/util.py
+++ b/services/image-rec-master/service/util.py
@@ -1,3 +1,6 @@
+import contextlib
+
+
 async def get_int_list(redis, key):
     """Get a list of integers on redis."""
     str_list = await redis.lrange(key, 0, -1)
@@ -12,3 +15,12 @@ async def get_int_set(redis, key):
     int_set = [int(i) for i in str_set]
 
     return int_set
+
+
+@contextlib.asynccontextmanager
+async def watch_keys(app, *keys):
+    """Acquire a Redis connection and watch keys."""
+    with await app['redis'] as r:
+        await r.watch(*keys)
+        yield r
+        await r.unwatch()

--- a/services/image-rec-master/test/test_app.py
+++ b/services/image-rec-master/test/test_app.py
@@ -9,6 +9,7 @@ from messages.image_rec_pb2 import PipelineState, Target
 from messages.interop_pb2 import Odlc
 
 from service.app import routes
+from service.util import get_int_list, get_int_set
 
 
 @pytest.fixture
@@ -65,6 +66,205 @@ async def test_get_pipeline_target_by_id(app_client, redis):
 
 async def test_get_pipeline_no_target(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/111')
+    assert resp.status == 404
+
+
+async def test_post_manual_targets(app_client, redis):
+    # Add two identical manual targets, both should post and not be
+    # filtered by uniqueness.
+    target = Target()
+    target.image_id = 2
+    target.odlc.shape = Odlc.SQUARE
+    target.odlc.autonomous = False
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target.SerializeToString())
+    assert resp.status == 201
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is False
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target.SerializeToString())
+    assert resp.status == 201
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 2
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is False
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    # Getting the targets back as well to check.
+    resp = await app_client.get('/api/pipeline/targets/1')
+    assert resp.status == 200
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is False
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    resp = await app_client.get('/api/pipeline/targets/2')
+    assert resp.status == 200
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 2
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is False
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    assert await get_int_set(redis, 'all-targets') == [1, 2]
+    assert await get_int_list(redis, 'unsubmitted-targets') == [2, 1]
+
+
+async def test_post_auto_targets(app_client, redis):
+    # Add two identical auto targets, one should post and not be
+    # filtered by uniqueness.
+    target = Target()
+    target.image_id = 2
+    target.odlc.shape = Odlc.SQUARE
+    target.odlc.autonomous = True
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target.SerializeToString())
+    assert resp.status == 201
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target.SerializeToString(),
+                                 allow_redirects=False)
+    assert resp.status == 303
+    assert resp.headers['Location'] == '/api/pipeline/targets/1'
+
+    # Getting the target back as well to check.
+    resp = await app_client.get('/api/pipeline/targets/1')
+    assert resp.status == 200
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    assert await get_int_set(redis, 'all-targets') == [1]
+    assert await get_int_list(redis, 'unsubmitted-targets') == [1]
+
+
+async def test_post_auto_targets_unique(app_client, redis):
+    # Add two different auto targets, both should post
+    target_1 = Target()
+    target_1.image_id = 2
+    target_1.odlc.shape = Odlc.SQUARE
+    target_1.odlc.background_color = Odlc.RED
+    target_1.odlc.autonomous = True
+
+    target_2 = Target()
+    target_2.image_id = 2
+    target_2.odlc.shape = Odlc.CIRCLE
+    target_2.odlc.alphanumeric = 'Z'
+    target_2.odlc.autonomous = True
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target_1.SerializeToString())
+    assert resp.status == 201
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.background_color == Odlc.RED
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=target_2.SerializeToString())
+    assert resp.status == 201
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 2
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.CIRCLE
+    assert ret_target.odlc.alphanumeric == 'Z'
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    # Getting the targets back as well to check.
+    resp = await app_client.get('/api/pipeline/targets/1')
+    assert resp.status == 200
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 1
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.SQUARE
+    assert ret_target.odlc.background_color == Odlc.RED
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    resp = await app_client.get('/api/pipeline/targets/2')
+    assert resp.status == 200
+
+    ret_target = Target.FromString(await resp.read())
+    assert ret_target.id == 2
+    assert ret_target.image_id == 2
+    assert ret_target.odlc.shape == Odlc.CIRCLE
+    assert ret_target.odlc.alphanumeric == 'Z'
+    assert ret_target.odlc.autonomous is True
+    assert ret_target.submitted is False
+    assert ret_target.errored is False
+    assert ret_target.removed is False
+
+    assert await get_int_set(redis, 'all-targets') == [1, 2]
+    assert await get_int_list(redis, 'unsubmitted-targets') == [2, 1]
+
+
+async def test_queue_target_removal(app_client, redis):
+    # Queue a target for removal, and then try again to make it 409.
+    resp = await app_client.post('/api/pipeline/targets',
+                                 data=Target().SerializeToString())
+    assert resp.status == 201
+
+    resp = await app_client.post('/api/pipeline/targets/1/queue-removal')
+    assert resp.status == 204
+    assert await get_int_list(redis, 'unremoved-targets') == [1]
+
+    resp = await app_client.post('/api/pipeline/targets/1/queue-removal')
+    assert resp.status == 409
+
+
+async def test_queue_target_removal_no_exist(app_client):
+    resp = await app_client.post('/api/pipeline/targets/1/queue-removal')
     assert resp.status == 404
 
 

--- a/services/image-rec-master/test/test_app.py
+++ b/services/image-rec-master/test/test_app.py
@@ -5,7 +5,7 @@ import zipfile
 from aiohttp import web
 import pytest
 
-from messages.image_rec_pb2 import PipelineState, Target
+from messages.image_rec_pb2 import PipelineState, PipelineTarget
 from messages.interop_pb2 import Odlc
 
 from service.app import routes
@@ -55,7 +55,7 @@ async def test_get_pipeline_target_by_id(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/4')
     assert resp.status == 200
 
-    msg = Target.FromString(await resp.read())
+    msg = PipelineTarget.FromString(await resp.read())
     assert msg.id == 4
     assert msg.image_id == 5
     assert msg.odlc.id == 6
@@ -72,7 +72,7 @@ async def test_get_pipeline_no_target(app_client, redis):
 async def test_post_manual_targets(app_client, redis):
     # Add two identical manual targets, both should post and not be
     # filtered by uniqueness.
-    target = Target()
+    target = PipelineTarget()
     target.image_id = 2
     target.odlc.shape = Odlc.SQUARE
     target.odlc.autonomous = False
@@ -81,7 +81,7 @@ async def test_post_manual_targets(app_client, redis):
                                  data=target.SerializeToString())
     assert resp.status == 201
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -94,7 +94,7 @@ async def test_post_manual_targets(app_client, redis):
                                  data=target.SerializeToString())
     assert resp.status == 201
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 2
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -107,7 +107,7 @@ async def test_post_manual_targets(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/1')
     assert resp.status == 200
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -119,7 +119,7 @@ async def test_post_manual_targets(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/2')
     assert resp.status == 200
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 2
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -135,7 +135,7 @@ async def test_post_manual_targets(app_client, redis):
 async def test_post_auto_targets(app_client, redis):
     # Add two identical auto targets, one should post and not be
     # filtered by uniqueness.
-    target = Target()
+    target = PipelineTarget()
     target.image_id = 2
     target.odlc.shape = Odlc.SQUARE
     target.odlc.autonomous = True
@@ -144,7 +144,7 @@ async def test_post_auto_targets(app_client, redis):
                                  data=target.SerializeToString())
     assert resp.status == 201
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -163,7 +163,7 @@ async def test_post_auto_targets(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/1')
     assert resp.status == 200
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -178,13 +178,13 @@ async def test_post_auto_targets(app_client, redis):
 
 async def test_post_auto_targets_unique(app_client, redis):
     # Add two different auto targets, both should post
-    target_1 = Target()
+    target_1 = PipelineTarget()
     target_1.image_id = 2
     target_1.odlc.shape = Odlc.SQUARE
     target_1.odlc.background_color = Odlc.RED
     target_1.odlc.autonomous = True
 
-    target_2 = Target()
+    target_2 = PipelineTarget()
     target_2.image_id = 2
     target_2.odlc.shape = Odlc.CIRCLE
     target_2.odlc.alphanumeric = 'Z'
@@ -194,7 +194,7 @@ async def test_post_auto_targets_unique(app_client, redis):
                                  data=target_1.SerializeToString())
     assert resp.status == 201
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -208,7 +208,7 @@ async def test_post_auto_targets_unique(app_client, redis):
                                  data=target_2.SerializeToString())
     assert resp.status == 201
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 2
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.CIRCLE
@@ -222,7 +222,7 @@ async def test_post_auto_targets_unique(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/1')
     assert resp.status == 200
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 1
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.SQUARE
@@ -235,7 +235,7 @@ async def test_post_auto_targets_unique(app_client, redis):
     resp = await app_client.get('/api/pipeline/targets/2')
     assert resp.status == 200
 
-    ret_target = Target.FromString(await resp.read())
+    ret_target = PipelineTarget.FromString(await resp.read())
     assert ret_target.id == 2
     assert ret_target.image_id == 2
     assert ret_target.odlc.shape == Odlc.CIRCLE
@@ -252,7 +252,7 @@ async def test_post_auto_targets_unique(app_client, redis):
 async def test_queue_target_removal(app_client, redis):
     # Queue a target for removal, and then try again to make it 409.
     resp = await app_client.post('/api/pipeline/targets',
-                                 data=Target().SerializeToString())
+                                 data=PipelineTarget().SerializeToString())
     assert resp.status == 201
 
     resp = await app_client.post('/api/pipeline/targets/1/queue-removal')


### PR DESCRIPTION
The original intention was to have the other image services implement this functionality, but implementing in `image-rec-master` allows for this service to contain the entire Redis pipeline state. This reduces the code duplication needed for implementing functionality in other services, and takes care of the logic instead of needing to implement it when it's needed.

Adds the following endpoints:

- `GET /api/pipeline/images/:id` - this one just gets an image.
- `POST /api/pipeline/images/start-processing-next-auto` - retrieves the next image to run auto image rec on.
- `POST /api/pipeline/images/:id/finish-processing-auto` - ends the processing window for auto image rec.
- `POST /api/pipeline/images/process-next-manual` - returns and marks the next manual image as processed.
- `POST /api/pipeline/targets` - submit a target
- `POST /api/pipeline/targets/:id/queue-removal` - trigger the removal process on an image. doesn't remove immediately, though.

Some `POST`s were used above since they are triggering an action in the background and aren't idempotent.

When submitting a target automatically, it will fail if 2 of the `shape`, `alphanumeric`, and `background_color` characteristics are the same as an auto image already submitted. This process can be enhanced in the future, but it is good for now. Note that limited the amount of auto submissions is not included in this PR and is left for a future one since it requires work on marking images as being skipped in the pipeline instead of allowing them to be processed.

Couple chores lumped in as well:
- Using the built-in `aiohttp` types for status codes like 204, 404, etc. since the newer code added uses them as well.
- Printing out html coverage for the service to see what was covered by the tests in a web page. 