### PR TITLE
Add support for Z Cam E1

### DIFF
--- a/services/imagery/Dockerfile
+++ b/services/imagery/Dockerfile
@@ -57,8 +57,11 @@ COPY --from=builder /builder/lib lib
 COPY /imagery/bin bin
 
 ENV PORT=8081 \
-    # Must be one of "gphoto2", "file", "sync".
+    # Must be one of "gphoto2", "z-cam-e1", "file", "sync".
     BACKEND='gphoto2' \
+    # Must be set if using the z-cam-e1 backend.
+    CAMERA_HOST='camera' \
+    CAMERA_PORT='80' \
     # Must be set if using the sync backend.
     IMAGERY_SYNC_HOST='' \
     IMAGERY_SYNC_PORT='8081' \

--- a/services/imagery/README.md
+++ b/services/imagery/README.md
@@ -6,10 +6,11 @@ The service has three backends which can be used:
 
 - `gphoto2` (default)
 
-  This backend takes images directly from a camera device passed in to the
-  container. Running as priviledged will do this if it's hard to find which
-  device is the camera. The gphoto2 dependency will autodetect the camera. If
-  no camera, or two or more cameras are found, an error will be thrown.
+  This backend takes images directly from a gphoto2-supported camera device
+  passed in to the container. Running as priviledged will do this if it's hard
+  to find which device is the camera. The gphoto2 dependency will autodetect
+  the camera. If no camera, or two or more cameras are found, an error will be
+  thrown.
 
   By default, the capture rate is set to take a photo every two seconds. To set
   a different interval, set the `CAPTURE_INTERVAL` environment variable. The
@@ -18,6 +19,15 @@ The service has three backends which can be used:
   To specify the telemetry service for tagging images, you can specify the
   `TELEMETRY_HOST` and `TELEMETRY_PORT` environment variables. These both
   default to `telemetry` and `5000`.
+
+- `z-cam-e1`
+
+  Takes photos with a [Z Cam E1](http://www.z-cam.com/e1/) camera using the
+  camera's HTTP API with the `CAMERA_HOST` and `CAMERA_PORT` environment
+  variables.
+
+  Similarly to the `gphoto2` backend, it uses a capture rate and optionally
+  uses a telemetry service.
 
 - `file`
 
@@ -41,6 +51,10 @@ onto the container, the service will use the images in that folder.
 
 - `PORT` - defaults to `8081`.
 - `BACKEND` - defaults to `gphoto2`.
+- `CAMERA_HOST` - required when using the `z-cam-e1` backend, defaults to
+  `camera`.
+- `CAMERA_PORT` - required when using the `z-cam-e1` backend, defaults to
+  `80`.
 - `IMAGERY_SYNC_HOST` - required when using the `sync` backend.
 - `IMAGERY_SYNC_PORT` - defaults to `8081`.
 - `TELEMETRY_HOST` - used with the `gphoto2` backend, defaults to `telemetry`.

--- a/services/imagery/bin/start-service.js
+++ b/services/imagery/bin/start-service.js
@@ -7,6 +7,8 @@ const Service = require('..');
 let service = new Service({
   port: process.env.PORT,
   backend: process.env.BACKEND,
+  cameraHost: process.env.CAMERA_HOST,
+  cameraPort: process.env.CAMERA_PORT,
   imagerySyncHost: process.env.IMAGERY_SYNC_HOST,
   imagerySyncPort: process.env.IMAGERY_SYNC_PORT,
   telemetryHost: process.env.TELEMETRY_HOST,

--- a/services/imagery/src/backends/camera-base-backend.js
+++ b/services/imagery/src/backends/camera-base-backend.js
@@ -1,0 +1,148 @@
+import request from 'superagent';
+import addProtobuf from 'superagent-protobuf';
+
+import logger from '../common/logger';
+import { imagery, telemetry } from '../messages';
+
+import { removeOrientation, wait } from '../util';
+
+addProtobuf(request);
+
+export default class CameraBaseBackend {
+  /**
+   * Base which takes care of taking images on an interval.
+   *
+   * Takes care of telemetry as well. Requires extension to implement
+   * camera capture behavior.
+   *
+   * Extended classes may implement the acquire() and release(camera)
+   * functions, but must implmenent capture(camera).
+   */
+
+  /** Create a new camera base backend. */
+  constructor(imageStore, interval, telemetryUrl) {
+    this._imageStore = imageStore;
+    this._interval = interval;
+    this._telemetryUrl = telemetryUrl;
+    this._active = false;
+  }
+
+  /** Get the camera and then start the loop in the background. */
+  async start() {
+    this._active = true;
+
+    // Run an acquire function if created on implementor class.
+    if (this.acquire) {
+      this._camera = await this.acquire();
+    } else {
+      this._camera = { };
+    }
+
+    this._runLoop();
+  }
+
+  /** Set a flag to kill the camera loop. */
+  async stop() {
+    // FIXME: Since there's not a proper shutdown, this will just
+    //        wait the duration of the capture interval for now.
+    this._active = false;
+    await wait(this._interval);
+
+    // Run a release function if created on implementor class.
+    if (this.release) {
+      await this.release();
+    }
+  }
+
+  /** Continuously take photos. */
+  async _runLoop() {
+    while (this._active) {
+      const startTime = Date.now();
+
+      let photo;
+      const metadataPromise = this._getMeta();
+
+      try {
+        photo = await this._takePhoto(this._camera);
+      } catch (err) {
+        const message = err.name + ': ' + err.message;
+        logger.error('Encountered an error in camera loop: ' + message);
+
+        // If we have an error, wait for a little to prevent these
+        // errors from happening too rapidly and then continue;
+        await wait(250);
+        continue;
+      }
+
+      // Register the photo in the background (no await). Note that
+      // this allows the telemetry to be collected if it takes longer
+      // than the photo, and doesn't prevent the next photo from
+      // being taken if the telemetry still hasn't been received yet.
+      metadataPromise.then((metadata) => {
+        return this._imageStore.addImage(photo, metadata);
+      }).catch((err) => {
+        const message = err.name + ': ' + err.message;
+        logger.error('Error while registering photo: ' + message);
+      });
+
+      const endTime = Date.now();
+
+      // If we haven't hit the interval time yet, wait some more
+      // time.
+      const duration = endTime - startTime;
+
+      if (duration < this._interval) {
+        await wait(this._interval - duration);
+      }
+    }
+  }
+
+  /** Get the metadata for the image. */
+  async _getMeta() {
+    // By default, we'll always list the current time.
+    const metadata = imagery.Image.create({
+      time: (new Date()).getTime() / 1000
+    });
+
+    // If a telemetry service url was given, we'll try requesting the
+    // latest camera telemetry. If it works, then we'll add it to the
+    // metadata.
+    if (this._telemetryUrl) {
+      try {
+        const telem = await this._getCameraTelem();
+
+        // FIXME: since we don't have gimbal data we'll just have to
+        //        assume that the camera is pointed straight down.
+        telem.roll = 0;
+        telem.pitch = 0;
+
+        metadata.has_telem = true;
+        metadata.telem = telem;
+      } catch (err) {
+        const message = err.name + ': ' + err.message;
+        logger.error('Error while requesting telemetry: ' + message);
+      }
+    }
+
+    return metadata;
+  }
+
+  /** Request the latest camera telemetry. */
+  async _getCameraTelem() {
+    const { body: telem } =
+      await request.get(this._telemetryUrl + '/api/camera-telem')
+        .proto(telemetry.CameraTelem)
+        .timeout(1500);
+
+    return telem;
+  }
+
+  /** Take a photo and return the data. */
+  async _takePhoto(camera) {
+    const photo = await this.capture(camera);
+
+    // Taking off EXIF data to prevent image preview applications
+    // from rotating it.
+    return await removeOrientation(photo);
+  }
+}

--- a/services/imagery/src/backends/gphoto2-backend.js
+++ b/services/imagery/src/backends/gphoto2-backend.js
@@ -1,146 +1,18 @@
 import { promisify } from 'util';
 
 import { GPhoto2 } from 'gphoto2';
-import request from 'superagent';
-import addProtobuf from 'superagent-protobuf';
 
-import logger from '../common/logger';
-import { imagery, telemetry } from '../messages';
+import CameraBaseBackend from './camera-base-backend';
 
-import { removeOrientation, wait } from '../util';
-
-addProtobuf(request);
-
-export default class GPhoto2Backend {
-  /** Create a new gphoto2 backend. */
-  constructor(imageStore, interval, telemetryUrl) {
-    this._imageStore = imageStore;
-    this._interval = interval;
-    this._telemetryUrl = telemetryUrl;
-    this._active = false;
-
-    this._gphoto2 = new GPhoto2();
-  }
-
-  /** Get the camrea and then start the loop in the background. */
-  async start() {
-    this._active = true;
-
-    const camera = await this._getCamera();
-
-    this._runLoop(camera);
-  }
-
-  /** Set a flag to kill the camera loop. */
-  async stop() {
-    // FIXME: Since there's not a proper shutdown, this will just
-    //        wait the duration of the capture interval for now.
-    this._active = false;
-    await wait(this._interval);
-  }
-
-  /** Continuously take photos. */
-  async _runLoop(camera) {
-    while (this._active) {
-      const startTime = Date.now();
-
-      let photo;
-      const metadataPromise = this._getMeta();
-
-      try {
-        photo = await this._takePhoto(camera);
-      } catch (err) {
-        const message = err.name + ': ' + err.message;
-        logger.error('Encountered an error in camera loop: ' + message);
-
-        // If we have an error, wait for a little to prevent these
-        // errors from happening too rapidly and then continue;
-        await wait(250);
-        continue;
-      }
-
-      // Register the photo in the background (no await). Note that
-      // this allows the telemetry to be collected if it takes longer
-      // than the photo, and doesn't prevent the next photo from
-      // being taken if the telemetry still hasn't been received yet.
-      metadataPromise.then((metadata) => {
-        return this._imageStore.addImage(photo, metadata);
-      }).catch((err) => {
-        const message = err.name + ': ' + err.message;
-        logger.error('Error while registering photo: ' + message);
-      });
-
-      const endTime = Date.now();
-
-      // If we haven't hit the interval time yet, wait some more
-      // time.
-      const duration = endTime - startTime;
-
-      if (duration < this._interval) {
-        await wait(this._interval - duration);
-      }
-    }
-  }
-
-  /** Get the metadata for the image. */
-  async _getMeta() {
-    // By default, we'll always list the current time.
-    const metadata = imagery.Image.create({
-      time: (new Date()).getTime() / 1000
-    });
-
-    // If a telemetry service url was given, we'll try requesting the
-    // latest camera telemetry. If it works, then we'll add it to the
-    // metadata.
-    if (this._telemetryUrl) {
-      try {
-        const telem = await this._getCameraTelem();
-
-        // FIXME: since we don't have gimbal data we'll just have to
-        //        assume that the camera is pointed straight down.
-        telem.roll = 0;
-        telem.pitch = 0;
-
-        metadata.has_telem = true;
-        metadata.telem = telem;
-      } catch (err) {
-        const message = err.name + ': ' + err.message;
-        logger.error('Error while requesting telemetry: ' + message);
-      }
-    }
-
-    return metadata;
-  }
-
-  /** Request the latest camera telemetry. */
-  async _getCameraTelem() {
-    const { body: telem } =
-      await request.get(this._telemetryUrl + '/api/camera-telem')
-        .proto(telemetry.CameraTelem)
-        .timeout(1500);
-
-    return telem;
-  }
-
-  /** Take a photo and return the data. */
-  async _takePhoto(camera) {
-    const photo = await promisify(camera.takePicture.bind(camera))({
-      download: true
-    });
-
-    if (!photo) {
-      throw Error('Image is empty');
-    }
-
-    // Taking off EXIF data to prevent image preview applications
-    // from rotating it.
-    return await removeOrientation(photo);
-  }
+export default class GPhoto2Backend extends CameraBaseBackend {
+  /** Camera backend for cameras with gphoto2 support. */
 
   /** Get the camera gphoto2 object. */
-  async _getCamera() {
+  async acquire() {
+    const gphoto2 = new GPhoto2();
+
     return await new Promise((resolve, reject) => {
-      this._gphoto2.list((list) => {
+      gphoto2.list((list) => {
         if (list.length == 0) {
           reject(Error('No camera found.'));
         } else if (list.length >= 2) {
@@ -150,5 +22,18 @@ export default class GPhoto2Backend {
         }
       });
     });
+  }
+
+  /** Capture an image using gphoto2. */
+  async capture(camera) {
+    const photo = await promisify(camera.takePicture.bind(camera))({
+      download: true
+    });
+
+    if (!photo) {
+      throw Error('Image is empty');
+    }
+
+    return photo;
   }
 }

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -41,7 +41,7 @@ export default class ZCamE1Backend extends CameraBaseBackend {
 
     // Each request comes with a code if it failed (except images).
     if (!buffer && res.body.code !== 0) {
-      throw new Error('Non-zero status code from z-cam-e1 for ' + endpoint);
+      throw new Error(`code ${res.body.code} from z-cam-e1 for ${endpoint}`);
     }
 
     return res.body;

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -34,16 +34,24 @@ export default class ZCamE1Backend extends CameraBaseBackend {
     await this._makeReq('/ctrl/session?action=quit');
   }
 
-  async _makeReq(endpoint, buffer = false) {
+  async _makeReq(endpoint, image = false) {
     const res = await request.get(this._cameraUrl + endpoint)
-      .buffer(buffer)
+      .buffer()
       .timeout(5000);
 
     // Each request comes with a code if it failed (except images).
-    if (!buffer && res.body.code !== 0) {
-      throw new Error(`code ${res.body.code} from z-cam-e1 for ${endpoint}`);
-    }
+    if (image) {
+      return res.body;
+    } else {
+      // We can't rely on the content type being set to
+      // `application/json` for the Z Cam E1.
+      const body = JSON.parse(res.text);
 
-    return res.body;
+      if (body.code !== 0) {
+        throw new Error(`code ${body.code} from z-cam-e1 for ${endpoint}`);
+      } else {
+        return body;
+      }
+    }
   }
 }

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -1,0 +1,49 @@
+import request from 'superagent';
+
+import CameraBaseBackend from './camera-base-backend';
+
+export default class ZCamE1Backend extends CameraBaseBackend {
+  /**
+   * Camera backend for the Z Cam E1.
+   *
+   * See Z Cam E1 documentation for explanation of requests:
+   *   https://github.com/imaginevision/Z-Camera-Doc/blob/master/E1/
+   */
+
+  constructor(imageStore, interval, cameraUrl, telemetryUrl) {
+    super(imageStore, interval, telemetryUrl);
+    this._cameraUrl = cameraUrl;
+  }
+
+  /** Get a session on the camera. */
+  async acquire() {
+    await this._makeReq('/ctrl/session');
+  }
+
+  /** Capture an image, download it, and remove it. */
+  async capture() {
+    const filename = (await this._makeReq('/ctrl/still?action=single')).msg;
+    const photo = await this._makeReq(filename, true);
+    await this._makeReq(filename + '?act=rm');
+
+    return photo;
+  }
+
+  /** Quit the session on the camera. */
+  async release() {
+    await this._makeReq('/ctrl/session?action=quit');
+  }
+
+  async _makeReq(endpoint, buffer = false) {
+    const res = await request.get(this._cameraUrl + endpoint)
+      .buffer(buffer)
+      .timeout(5000);
+
+    // Each request comes with a code if it failed (except images).
+    if (!buffer && res.body.code !== 0) {
+      throw new Error('Non-zero status code from z-cam-e1 for ' + endpoint);
+    }
+
+    return res.body;
+  }
+}

--- a/services/imagery/test/backends/z-cam-e1-backend.test.js
+++ b/services/imagery/test/backends/z-cam-e1-backend.test.js
@@ -25,23 +25,26 @@ test('capture images with telemetry when available', async () => {
   const t1 = telemetry.CameraTelem.encode({ time: 1, lat: 2 }).finish();
 
   const cameraApi = nock('http://camera:1234')
-    .defaultReplyHeaders({ 'content-type': 'application/json' })
     .get('/ctrl/session')
-    .reply(200, { code: 0, desc: '', msg: '' })
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
     .get('/ctrl/still?action=single')
-    .reply(200, { code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6391.JPG' })
+    .reply(200, JSON.stringify({
+      code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6391.JPG'
+    }))
     .get('/DCIM/100MEDIA/EYED6391.JPG')
     .reply(200, image, { 'content-type': 'image/jpeg' })
     .get('/DCIM/100MEDIA/EYED6391.JPG?act=rm')
-    .reply(200, { code: 0, desc: '', msg: '' })
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
     .get('/ctrl/still?action=single')
-    .reply(200, { code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6392.JPG' })
+    .reply(200, JSON.stringify({
+      code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6392.JPG'
+    }))
     .get('/DCIM/100MEDIA/EYED6392.JPG')
     .reply(200, image, { 'content-type': 'image/jpeg' })
     .get('/DCIM/100MEDIA/EYED6392.JPG?act=rm')
-    .reply(200, { code: 0, desc: '', msg: '' })
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
     .get('/ctrl/session?action=quit')
-    .reply(200, { code: 0, desc: '', msg: '' });
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }));
 
   const telemApi = nock('http://telemetry:8081')
     .defaultReplyHeaders({ 'content-type': 'application/x-protobuf' })
@@ -85,19 +88,18 @@ test('capture images with telemetry when available', async () => {
 
 test('backend continues after errors', async () => {
   const cameraApi = nock('http://camera:1234')
-    .defaultReplyHeaders({ 'content-type': 'application/json' })
     .get('/ctrl/session')
-    .reply(200, { code: 0, desc: '', msg: '' })
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
     .get('/ctrl/still?action=single')
     .reply(500)
     .get('/ctrl/still?action=single')
-    .reply(200, { code: 1, desc: '', msg: '' })
+    .reply(200, JSON.stringify({ code: 1, desc: '', msg: '' }))
     .get('/ctrl/still?action=single')
-    .reply(200, { code: 0, desc: '', msg: '/empty-image' })
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '/empty-image' }))
     .get('/empty-image')
     .reply(200, '', { 'content-type': 'image/jpeg' })
     .get('/ctrl/session?action=quit')
-    .reply(200, { code: 0, desc: '', msg: '' });
+    .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }));
 
   const backend = new ZCamE1Backend(
     {}, 500, 'http://camera:1234'

--- a/services/imagery/test/backends/z-cam-e1-backend.test.js
+++ b/services/imagery/test/backends/z-cam-e1-backend.test.js
@@ -1,0 +1,137 @@
+import path from 'path';
+
+import fileType from 'file-type';
+import fs from 'fs-extra';
+import nock from 'nock';
+
+import logger from '../../src/common/logger';
+import { telemetry } from '../../src/messages';
+
+import ZCamE1Backend from '../../src/backends/z-cam-e1-backend';
+import { wait } from '../../src/util';
+
+afterEach(async () => {
+  jest.clearAllMocks();
+});
+
+test('capture images with telemetry when available', async () => {
+  const imageFilename = path.join(__dirname, '../fixtures/shape-1.jpg');
+  const image = await fs.readFile(imageFilename, { encoding: null });
+
+  const imageStore = {
+    addImage: jest.fn().mockImplementation(() => Promise.resolve())
+  };
+
+  const t1 = telemetry.CameraTelem.encode({ time: 1, lat: 2 }).finish();
+
+  const cameraApi = nock('http://camera:1234')
+    .defaultReplyHeaders({ 'content-type': 'application/json' })
+    .get('/ctrl/session')
+    .reply(200, { code: 0, desc: '', msg: '' })
+    .get('/ctrl/still?action=single')
+    .reply(200, { code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6391.JPG' })
+    .get('/DCIM/100MEDIA/EYED6391.JPG')
+    .reply(200, image, { 'content-type': 'image/jpeg' })
+    .get('/DCIM/100MEDIA/EYED6391.JPG?act=rm')
+    .reply(200, { code: 0, desc: '', msg: '' })
+    .get('/ctrl/still?action=single')
+    .reply(200, { code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6392.JPG' })
+    .get('/DCIM/100MEDIA/EYED6392.JPG')
+    .reply(200, image, { 'content-type': 'image/jpeg' })
+    .get('/DCIM/100MEDIA/EYED6392.JPG?act=rm')
+    .reply(200, { code: 0, desc: '', msg: '' })
+    .get('/ctrl/session?action=quit')
+    .reply(200, { code: 0, desc: '', msg: '' });
+
+  const telemApi = nock('http://telemetry:8081')
+    .defaultReplyHeaders({ 'content-type': 'application/x-protobuf' })
+    .get('/api/camera-telem').reply(200, t1)
+    .get('/api/camera-telem').reply(500);
+
+  const backend = new ZCamE1Backend(
+    imageStore, 500, 'http://camera:1234', 'http://telemetry:8081'
+  );
+  const spy = jest.spyOn(logger, 'error');
+
+  await backend.start();
+  await wait(250);
+
+  try {
+    expect(spy).not.toHaveBeenCalled();
+
+    logger.transports[0].silent = true;
+    await wait(500);
+  } finally {
+    logger.transports[0].silent = false;
+    await backend.stop();
+  }
+
+  cameraApi.done();
+  telemApi.done();
+
+  expect(imageStore.addImage).toBeCalledTimes(2);
+
+  expect(fileType(imageStore.addImage.mock.calls[0][0]).ext).toEqual('jpg');
+  expect(imageStore.addImage.mock.calls[0][1].time).toBeDefined();
+  expect(imageStore.addImage.mock.calls[0][1].has_telem).toBeTruthy();
+  expect(imageStore.addImage.mock.calls[0][1].telem.lat).toEqual(2);
+  expect(fileType(imageStore.addImage.mock.calls[1][0]).ext).toEqual('jpg');
+  expect(imageStore.addImage.mock.calls[1][1].time).toBeDefined();
+  expect(imageStore.addImage.mock.calls[1][1].has_telem).toBeFalsy();
+
+  expect(spy).toHaveBeenCalledTimes(1);
+  expect(spy.mock.calls[0][0]).toMatch(/Error while requesting telemetry/);
+});
+
+test('backend continues after errors', async () => {
+  const cameraApi = nock('http://camera:1234')
+    .defaultReplyHeaders({ 'content-type': 'application/json' })
+    .get('/ctrl/session')
+    .reply(200, { code: 0, desc: '', msg: '' })
+    .get('/ctrl/still?action=single')
+    .reply(500)
+    .get('/ctrl/still?action=single')
+    .reply(200, { code: 1, desc: '', msg: '' })
+    .get('/ctrl/still?action=single')
+    .reply(200, { code: 0, desc: '', msg: '/empty-image' })
+    .get('/empty-image')
+    .reply(200, '', { 'content-type': 'image/jpeg' })
+    .get('/ctrl/session?action=quit')
+    .reply(200, { code: 0, desc: '', msg: '' });
+
+  const backend = new ZCamE1Backend(
+    {}, 500, 'http://camera:1234'
+  );
+
+  logger.transports[0].silent = true;
+
+  await backend.start();
+
+  // Check error conditions of 500 status code, a bad code in the
+  // JSON, and an empty image, so it should error out three times
+  // after 500 ms. There should be some lag to prevent errors from
+  // repeating quickly (this prevents a device from being overloaded
+  // with requests).
+  const spy = jest.spyOn(logger, 'error');
+
+  await wait(5);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  await wait(240);
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  await wait(10);
+  expect(spy).toHaveBeenCalledTimes(2);
+
+  await wait(240);
+  expect(spy).toHaveBeenCalledTimes(2);
+
+  await wait(10);
+  expect(spy).toHaveBeenCalledTimes(3);
+
+  await backend.stop();
+
+  logger.transports[0].silent = false;
+
+  cameraApi.done();
+});

--- a/services/imagery/test/service.test.js
+++ b/services/imagery/test/service.test.js
@@ -11,11 +11,10 @@ gphoto2.GPhoto2 = jest.fn(() => {
 });
 
 nock('http://camera:1234')
-  .defaultReplyHeaders({ 'content-type': 'application/json' })
   .get('/ctrl/session')
-  .reply(200, { code: 0, desc: '', msg: '' })
+  .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
   .get('/ctrl/session?action=quit')
-  .reply(200, { code: 0, desc: '', msg: '' });
+  .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }));
 
 const names = ['gphoto2', 'z-cam-e1', 'file', 'sync'];
 const options = [

--- a/services/imagery/test/service.test.js
+++ b/services/imagery/test/service.test.js
@@ -1,5 +1,6 @@
 import gphoto2 from 'gphoto2';
 import _ from 'lodash';
+import nock from 'nock';
 
 import logger from '../src/common/logger';
 
@@ -9,10 +10,19 @@ gphoto2.GPhoto2 = jest.fn(() => {
   return { list: jest.fn((cb => cb([{ }]))) };
 });
 
-const names = ['gphoto2', 'file', 'sync'];
+nock('http://camera:1234')
+  .defaultReplyHeaders({ 'content-type': 'application/json' })
+  .get('/ctrl/session')
+  .reply(200, { code: 0, desc: '', msg: '' })
+  .get('/ctrl/session?action=quit')
+  .reply(200, { code: 0, desc: '', msg: '' });
+
+const names = ['gphoto2', 'z-cam-e1', 'file', 'sync'];
 const options = [
   { port: 8081, backend: 'gphoto2', telemetryHost: 'telemetry',
     telemetryPort: 5000, captureInterval: 4000 },
+  { port: 8081, backend: 'z-cam-e1', cameraHost: 'camera', cameraPort: 1234,
+    telemetryHost: 'telemetry', telemetryPort: 5000, captureInterval: 4000 },
   { port: 8081, backend: 'file' },
   { port: 8081, backend: 'sync', imagerySyncHost: 'imagery',
     imagerySyncPort: 8082 }


### PR DESCRIPTION
This enables the Z Cam E1 camera to be used in the imagery service by using the `CAMERA_HOST` and `CAMERA_PORT` environment variables.

In the process, a generic camera backend was created to share code between the the backend for `gphoto2`-supported cameras and the Z Cam E1 since the capture workflow is similar, and allows other camera backends to be added off of this.

I tested this using commands recorded from the Z Cam E1, but this should be tested with the actual camera before merging.