### PR TITLE
Use a mirror of the interop server for testing

### DIFF
--- a/services/interop-proxy/test.sh
+++ b/services/interop-proxy/test.sh
@@ -16,7 +16,7 @@ start_interop_server() {
 
     docker run -itd --rm --net=interop-proxy-test-net --ip=172.37.0.2 \
             -p 8081:80 --name interop-proxy-test \
-            auvsisuas/interop-server:2018.12 \
+            uavaustin/interop-server:2018.12 \
             > /dev/null
 
     if [ "$?" -ne 0 ]; then

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         ipv4_address: 172.16.238.10
 
   interop-server:
-    image: auvsisuas/interop-server:2018.12
+    image: uavaustin/interop-server:2018.12
     ports:
       - '8080:80'
     networks:


### PR DESCRIPTION
The images on the `auvsisuas` Docker Hub organization are being deleted, and because of how fast the old one was removed given that the new one had been out a little more than a week, a mirror is needed to prevent build failures and other development problems.

In the future this also allows for mirroring images in the middle of a month, instead of waiting until the next.