### PR TITLE
Update Elixir and Mix dependencies for interop-proxy

### DIFF
--- a/services/interop-proxy/Dockerfile
+++ b/services/interop-proxy/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_BUILDER=elixir:1.6-alpine
+ARG BASE_BUILDER=elixir:1.8-alpine
 ARG BASE=alpine:3.9
 
 FROM ${BASE_BUILDER} as builder

--- a/services/interop-proxy/Dockerfile.test
+++ b/services/interop-proxy/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG BASE=elixir:1.6-alpine
+ARG BASE=elixir:1.8-alpine
 
 FROM ${BASE}
 

--- a/services/interop-proxy/mix.exs
+++ b/services/interop-proxy/mix.exs
@@ -5,7 +5,7 @@ defmodule InteropProxy.Mixfile do
     [
       app: :interop_proxy,
       version: "0.1.0",
-      elixir: "~> 1.5",
+      elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env),
       compilers: [:phoenix] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
@@ -27,14 +27,14 @@ defmodule InteropProxy.Mixfile do
 
   defp deps do
     [
-      {:cowboy, "~> 1.0"},
+      {:cowboy, "~> 2.6"},
       {:distillery, "~> 1.3", runtime: false},
       {:exprotobuf, "~> 1.2.9"},
       {:flasked, "~> 0.4.0"},
-      {:httpoison, "~> 0.13.0"},
-      {:phoenix, "~> 1.3.0"},
-      {:phoenix_pubsub, "~> 1.0"},
-      {:plug_cowboy, "~> 1.0"},
+      {:httpoison, "~> 1.5"},
+      {:phoenix, "~> 1.4"},
+      {:phoenix_pubsub, "~> 1.1"},
+      {:plug_cowboy, "~> 2.0"},
       {:poison, "~> 3.1.0"}
     ]
   end


### PR DESCRIPTION
Updates Elixir from 1.6 to 1.8 and updates Mix deps to new versions except for Poison since Phoenix wasn't compatible with 4.0 yet.

I was having some OpenSSL problems again, one of the dependencies being updated fixed the problem, but it's good to have them all updated anyways.