### PR TITLE
Update Interop Proxy for mid-May Interop Server release

### DIFF
--- a/services/common/messages/interop.proto
+++ b/services/common/messages/interop.proto
@@ -30,10 +30,7 @@ message AerialPosition {
     double alt_msl = 3;
 }
 
-// Mission on the interop server.
-// 
-// Note the lack of an active field, as all missions passed into the
-// stack will be assumed to be active.
+// Mission on the interop server with the desired mission ID.
 message InteropMission {
     message FlyZone {
         double alt_msl_max = 1;
@@ -42,11 +39,11 @@ message InteropMission {
     }
 
     double time = 1;
-    // If there even is an active mission or not.
+    // If the mission with given id exists.
     bool current_mission = 2;
     Position air_drop_pos = 3;
     repeated FlyZone fly_zones = 4;
-    Position home_pos = 5;
+    // 5 reserved.
     repeated AerialPosition waypoints = 6;
     Position off_axis_pos = 7;
     Position emergent_pos = 8;
@@ -68,7 +65,7 @@ message Obstacles {
 
     double time = 1;
     repeated StationaryObstacle stationary = 2;
-    repeated MovingObstacle moving = 3;
+    // 3 reserved.
 }
 
 // Telemetry to upload to the server.

--- a/services/interop-proxy/README.md
+++ b/services/interop-proxy/README.md
@@ -8,15 +8,16 @@ with the server.
 
 ## Running the Image
 
-When running the image, make sure to pass in the `INTEROP_URL`, `USERNAME`, and
-`PASSWORD` envrionment variables. They default to `0.0.0.0:8080`, `testuser`,
-and `testpass`, respectively.
+When running the image, make sure to pass in the `INTEROP_URL`, `USERNAME`,
+`PASSWORD`, `MISSION_ID` envrionment variables. They default to `0.0.0.0:8080`,
+`testuser`, `testpass`, and `1` respectively.
 
 ```
 $ docker run -it -p 8000:8000 \
     -e INTEROP_URL="192.168.0.5:8080" \
     -e USERNAME="someuser" \
     -e PASSWORD="somepass" \
+    -e MISSION_ID="1" \
     uavaustin/interop-proxy
 ```
 
@@ -38,13 +39,13 @@ If the interop server could not be reached, a `503` status code will be sent.
 
 - `GET /api/mission`
 
-  Lists the active mission on the server.
+  Return the mission using the given mission id.
 
-  Note that if there isn't an active mession, the reply will have all defaults
-  and `current_mission` will be set to `false`.
+  If the set mission is not accessible, there isn't an active mission and the
+  reply will have all defaults and `current_mission` will be set to `false`.
 
-  On successful response: `200` status code with `interop::Mission` Protobuf
-  message.
+  On successful response: `200` status code with `interop::InteropMission`
+  Protobuf message.
 
 - `GET /api/obstacles`
 

--- a/services/interop-proxy/lib/interop_proxy.ex
+++ b/services/interop-proxy/lib/interop_proxy.ex
@@ -11,35 +11,45 @@ defmodule InteropProxy do
   alias InteropProxy.Request
   alias InteropProxy.Sanitize
 
-  import InteropProxy.Session, only: [url: 0, cookie: 0]
+  import InteropProxy.Session, only: [url: 0, cookie: 0, mission_id: 0]
 
   @doc """
-  Return the active mission on the server.
+  Return the mission on the server.
   """
-  def get_active_mission do
-    case Request.get_missions url(), cookie() do
-      {:ok, missions} ->
-        message = missions
-        |> Enum.find(fn mission -> mission["active"] === true end)
-        |> Sanitize.sanitize_mission
-
+  def get_mission do
+    case Request.get_mission url(), cookie(), mission_id() do
+      {:ok, mission} ->
+        message = mission |> Sanitize.sanitize_mission
         {:ok, message}
+
+      {:error, {:message, 404, _content}} ->
+        message = nil |> Sanitize.sanitize_mission
+        {:ok, message}
+
       {:error, _} = other ->
         other
     end
   end
 
   @doc """
-  Same as `get_active_mission/0`, but raises an exception on failure.
+  Same as `get_mission/0`, but raises an exception on failure.
   """
-  def get_active_mission!, do: when_ok get_active_mission()
+  def get_mission!, do: when_ok get_mission()
 
   @doc """
-  Return the stationary and moving obstacles on the server.
+  Return the stationary on the server from the mission.
   """
   def get_obstacles do
-    case Request.get_obstacles url(), cookie() do
-      {:ok, obstacles}    -> {:ok, Sanitize.sanitize_obstacles(obstacles)}
+    case Request.get_mission url(), cookie(), mission_id() do
+      {:ok, mission} ->
+        message = mission |> Sanitize.sanitize_obstacles
+
+        {:ok, message}
+
+      {:error, {:message, 404, _content}} ->
+        message = [] |> Sanitize.sanitize_mission
+        {:ok, message}
+
       {:error, _} = other -> other
     end
   end
@@ -75,7 +85,7 @@ defmodule InteropProxy do
   def post_odlc(%Odlc{} = odlc) do
     {outgoing_odlc, image} = Sanitize.sanitize_outgoing_odlc odlc
 
-    case Request.post_odlc url(), cookie(), outgoing_odlc do
+    case Request.post_odlc url(), cookie(), outgoing_odlc, mission_id() do
       {:ok, returned} ->
         returned = Sanitize.sanitize_odlc returned
 
@@ -104,7 +114,7 @@ defmodule InteropProxy do
   the images, pass in `image: true` with the options.
   """
   def get_odlcs(opts \\ []) do
-    case Request.get_odlcs url(), cookie() do
+    case Request.get_odlcs url(), cookie(), mission_id() do
       {:ok, odlcs} ->
         image_resp_list = Enum.map odlcs, fn odlc ->
           case Keyword.get opts, :image, false do
@@ -180,7 +190,7 @@ defmodule InteropProxy do
   def put_odlc(id, %Odlc{} = odlc) do
     {outgoing_odlc, image} = Sanitize.sanitize_outgoing_odlc odlc
 
-    case Request.put_odlc url(), cookie(), id, outgoing_odlc do
+    case Request.put_odlc url(), cookie(), id, outgoing_odlc, mission_id() do
       {:ok, returned} ->
         returned = Sanitize.sanitize_odlc returned
 

--- a/services/interop-proxy/lib/interop_proxy/application.ex
+++ b/services/interop-proxy/lib/interop_proxy/application.ex
@@ -17,6 +17,7 @@ defmodule InteropProxy.Application do
       url:        Application.get_env(:interop_proxy, :url),
       username:   Application.get_env(:interop_proxy, :username),
       password:   Application.get_env(:interop_proxy, :password),
+      mission_id: Application.get_env(:interop_proxy, :mission_id),
       name:       InteropProxy.Session,
       respond_to: self()
     ]

--- a/services/interop-proxy/lib/interop_proxy/message.ex
+++ b/services/interop-proxy/lib/interop_proxy/message.ex
@@ -21,18 +21,13 @@ defmodule InteropProxy.Message do
 
       iex> alias InteropProxy.Message
       iex> alias InteropProxy.Message.Interop.InteropMission
-      iex> map = %{home_pos: %{lat: 1}, waypoints: [%{lat: 12,
-      ...>   lon: 23}]}
+      iex> map = %{waypoints: [%{lat: 12, lon: 23}]}
       iex> Message.form_message map, InteropMission
       %InteropProxy.Message.Interop.InteropMission{
         air_drop_pos: nil,
         current_mission: nil,
         emergent_pos: nil,
         fly_zones: [],
-        home_pos: %InteropProxy.Message.Interop.Position{
-          lat: 1,
-          lon: nil
-        },
         off_axis_pos: nil,
         search_area: [],
         time: nil,

--- a/services/interop-proxy/lib/interop_proxy/sanitize.ex
+++ b/services/interop-proxy/lib/interop_proxy/sanitize.ex
@@ -24,23 +24,49 @@ defmodule InteropProxy.Sanitize do
     %InteropMission{
       time: time(),
       current_mission: true,
-      air_drop_pos: mission["air_drop_pos"] |> sanitize_position,
-      fly_zones: mission["fly_zones"] |> sanitize_fly_zones,
-      home_pos: mission["home_pos"] |> sanitize_position,
-      waypoints: mission["mission_waypoints"] |> sanitize_aerial_position,
-      off_axis_pos: mission["off_axis_odlc_pos"] |> sanitize_position,
-      emergent_pos: mission["emergent_last_known_pos"] |> sanitize_position,
-      search_area: mission["search_grid_points"] |> sanitize_aerial_position
+      air_drop_pos:
+        mission
+        |> Map.get("airDropPos", %{})
+        |> sanitize_position,
+      fly_zones:
+        mission
+        |> Map.get("flyZones", %{})
+        |> sanitize_fly_zones,
+      waypoints:
+        mission
+        |> Map.get("waypoints", %{})
+        |> sanitize_aerial_position,
+      off_axis_pos:
+        mission
+        |> Map.get("offAxisOdlcPos", %{})
+        |> sanitize_position,
+      emergent_pos:
+        mission
+        |> Map.get("emergentLastKnownPos", %{})
+        |> sanitize_position,
+      search_area:
+        mission
+        |> Map.get("searchGridPoints", %{})
+        |> sanitize_aerial_position
     }
   end
 
   defp sanitize_fly_zones(fly_zones) do
     fly_zones
-    |> Enum.map(fn fly_zone -> 
+    |> Enum.map(fn fly_zone ->
       %FlyZone{
-        alt_msl_max: fly_zone["altitude_msl_max"] |> meters,
-        alt_msl_min: fly_zone["altitude_msl_min"] |> meters,
-        boundary: fly_zone["boundary_pts"] |> sanitize_position
+        alt_msl_max:
+          fly_zone
+          |> Map.get("altitudeMax", 0.0)
+          |> meters,
+        alt_msl_min:
+          fly_zone
+          |> Map.get("altitudeMin", 0.0)
+          |> meters,
+        boundary:
+          fly_zone
+          |> Map.get("boundaryPoints", %{})
+          |> sanitize_position
       }
     end)
   end
@@ -48,8 +74,10 @@ defmodule InteropProxy.Sanitize do
   def sanitize_obstacles(obstacles) do
     %Obstacles{
       time: time(),
-      stationary: obstacles["stationary_obstacles"]
-                  |> sanitize_stationary_obstacles
+      stationary:
+        obstacles
+        |> Map.get("stationaryObstacles", [])
+        |> sanitize_stationary_obstacles
     }
   end
 
@@ -57,35 +85,74 @@ defmodule InteropProxy.Sanitize do
     stationary
     |> Enum.map(fn obs ->
       %StationaryObstacle{
-        pos: obs |> sanitize_position,
-        height: obs["cylinder_height"] |> meters,
-        radius: obs["cylinder_radius"] |> meters
+        pos:
+          obs
+          |> sanitize_position,
+        height:
+          obs
+          |> Map.get("height", 0.0)
+          |> meters,
+        radius:
+          obs
+          |> Map.get("radius", 0.0)
+          |> meters
       }
     end)
   end
 
   def sanitize_outgoing_telemetry(%InteropTelem{} = telem) do
     %{
-      latitude: telem.pos |> sanitize_outgoing_latitude,
-      longitude: telem.pos |> sanitize_outgoing_longitude,
-      altitude_msl: telem.pos.alt_msl |> feet,
-      uas_heading: telem.yaw
+      latitude:
+        telem.pos
+        |> sanitize_outgoing_latitude,
+      longitude:
+        telem.pos
+        |> sanitize_outgoing_longitude,
+      altitude:
+        telem.pos.alt_msl
+        |> feet,
+      heading: telem.yaw
     }
   end
 
   def sanitize_odlc(odlc, image \\ <<>>) do
     %Odlc{
       time: time(),
-      id: odlc["id"],
-      type: odlc["type"] |> string_to_atom(:type),
-      pos: odlc |> sanitize_position,
-      orientation: odlc["orientation"] |> sanitize_orientation,
-      shape: odlc["shape"] |> string_to_atom(:shape),
-      background_color: odlc["background_color"] |> string_to_atom(:color),
-      alphanumeric: odlc["alphanumeric"],
-      alphanumeric_color: odlc["alphanumeric_color"] |> string_to_atom(:color),
-      description: odlc["description"],
-      autonomous: odlc["autonomous"],
+      id:
+        odlc
+        |> Map.get("id", 0),
+      type:
+        odlc
+        |> Map.get("type")
+        |> string_to_atom(:type),
+      pos:
+        odlc
+        |> sanitize_position,
+      orientation:
+        odlc
+        |> Map.get("orientation")
+        |> sanitize_orientation,
+      shape:
+        odlc
+        |> Map.get("shape")
+        |> string_to_atom(:shape),
+      background_color:
+        odlc
+        |> Map.get("shapeColor")
+        |> string_to_atom(:color),
+      alphanumeric:
+        odlc
+        |> Map.get("alphanumeric", ""),
+      alphanumeric_color:
+        odlc
+        |> Map.get("alphanumericColor")
+        |> string_to_atom(:color),
+      description:
+        odlc
+        |> Map.get("description", ""),
+      autonomous:
+        odlc
+        |> Map.get("autonomous", false),
       image: image
     }
   end
@@ -98,30 +165,74 @@ defmodule InteropProxy.Sanitize do
 
   def sanitize_outgoing_odlc(%Odlc{type: :EMERGENT} = odlc) do
     outgoing_odlc = %{
-      type: odlc.type |> atom_to_string,
-      latitude: odlc.pos |> sanitize_outgoing_latitude,
-      longitude: odlc.pos |> sanitize_outgoing_longitude,
-      description: parse_string(odlc.description),
-      autonomous: odlc.autonomous |> (&(if &1 === nil, do: false, else: &1)).()
+      type:
+        odlc.type
+        |> atom_to_string,
+      latitude:
+        odlc.pos
+        |> sanitize_outgoing_latitude,
+      longitude:
+        odlc.pos
+        |> sanitize_outgoing_longitude,
+      description:
+        odlc.description
+        |> parse_string,
+      autonomous:
+        case odlc.autonomous do
+          nil -> false
+          bool -> bool
+        end
     }
 
-    {outgoing_odlc, odlc.image |> (&(if &1 === nil, do: <<>>, else: &1)).()}
+    outgoing_image =
+      case odlc.image do
+        nil -> <<>>
+        string -> string
+      end 
+
+    {outgoing_odlc, outgoing_image}
   end
 
   def sanitize_outgoing_odlc(%Odlc{} = odlc) do
     outgoing_odlc = %{
-      type: odlc.type |> atom_to_string,
-      latitude: odlc.pos |> sanitize_outgoing_latitude,
-      longitude: odlc.pos |> sanitize_outgoing_longitude,
-      orientation: odlc.orientation |> sanitize_outgoing_orientation,
-      shape: odlc.shape |> atom_to_string,
-      background_color: odlc.background_color |> atom_to_string,
-      alphanumeric: odlc.alphanumeric,
-      alphanumeric_color: odlc.alphanumeric_color |> atom_to_string,
-      autonomous: odlc.autonomous |> (&(if &1 === nil, do: false, else: &1)).()
+      type:
+        odlc.type
+        |> atom_to_string,
+      latitude:
+        odlc.pos
+        |> sanitize_outgoing_latitude,
+      longitude:
+        odlc.pos
+        |> sanitize_outgoing_longitude,
+      orientation:
+        odlc.orientation
+        |> sanitize_outgoing_orientation,
+      shape:
+        odlc.shape
+        |> atom_to_string,
+      shapeColor:
+        odlc.background_color
+        |> atom_to_string,
+      alphanumeric:
+        odlc.alphanumeric
+        |> parse_string,
+      alphanumeric_color:
+        odlc.alphanumeric_color
+        |> atom_to_string,
+      autonomous:
+        case odlc.autonomous do
+          nil -> false
+          bool -> bool
+        end
     }
 
-    {outgoing_odlc, odlc.image |> (&(if &1 === nil, do: <<>>, else: &1)).()}
+    outgoing_image =
+      case odlc.image do
+        nil -> <<>>
+        string -> string
+      end 
+
+    {outgoing_odlc, outgoing_image}
   end
 
   def sanitize_message(text) do
@@ -131,35 +242,39 @@ defmodule InteropProxy.Sanitize do
     }
   end
 
-  defp sort_order(list) do
-    list
-    |> Enum.sort(fn a, b -> a["order"] < b["order"] end)
-  end
-
   defp sanitize_position(pos) when is_list(pos) do
     pos
-    |> sort_order
     |> Enum.map(&sanitize_position/1)
   end
 
   defp sanitize_position(pos) do
     %Position{
-      lat: pos["latitude"],
-      lon: pos["longitude"]
+      lat:
+        pos
+        |> Map.get("latitude", 0.0),
+      lon:
+        pos
+        |> Map.get("longitude", 0.0),
     }
   end
 
   defp sanitize_aerial_position(pos) when is_list(pos) do
     pos
-    |> sort_order
     |> Enum.map(&sanitize_aerial_position/1)
   end
 
   defp sanitize_aerial_position(pos) do
     %AerialPosition{
-      lat: pos["latitude"],
-      lon: pos["longitude"],
-      alt_msl: pos["altitude_msl"] |> meters
+      lat:
+        pos
+        |> Map.get("latitude", 0.0),
+      lon:
+        pos
+        |> Map.get("longitude", 0.0),
+      alt_msl:
+        pos
+        |> Map.get("altitude", 0.0)
+        |> meters
     }
   end
 
@@ -173,31 +288,30 @@ defmodule InteropProxy.Sanitize do
 
   defp sanitize_orientation(string) do
     case string do
-      nil  -> :UNKNOWN_ORIENTATION
-      "n"  -> :NORTH
-      "ne" -> :NORTHEAST
-      "e"  -> :EAST
-      "se" -> :SOUTHEAST
-      "s"  -> :SOUTH
-      "sw" -> :SOUTHWEST
-      "w"  -> :WEST
-      "nw" -> :NORTHWEST
+      nil -> :UNKNOWN_ORIENTATION
+      "N" -> :NORTH
+      "NE" -> :NORTHEAST
+      "E" -> :EAST
+      "SE" -> :SOUTHEAST
+      "S" -> :SOUTH
+      "SW" -> :SOUTHWEST
+      "W" -> :WEST
+      "NW" -> :NORTHWEST
     end
   end
 
-  defp sanitize_outgoing_orientation(nil), do: nil
-
   defp sanitize_outgoing_orientation(atom) do
     case atom do
+      nil -> nil
       :UNKNOWN_ORIENTATION -> nil
-      :NORTH               -> "n"
-      :NORTHEAST           -> "ne"
-      :EAST                -> "e"
-      :SOUTHEAST           -> "se"
-      :SOUTH               -> "s"
-      :SOUTHWEST           -> "sw"
-      :WEST                -> "w"
-      :NORTHWEST           -> "nw"
+      :NORTH -> "N"
+      :NORTHEAST -> "NE"
+      :EAST -> "E"
+      :SOUTHEAST -> "SE"
+      :SOUTH -> "S"
+      :SOUTHWEST -> "SW"
+      :WEST -> "W"
+      :NORTHWEST -> "NW"
     end
   end
 
@@ -205,22 +319,22 @@ defmodule InteropProxy.Sanitize do
 
   defp feet(meters), do: meters / 0.3048
 
+  defp string_to_atom(nil, :type), do: :STANDARD
   defp string_to_atom(nil, :shape), do: :UNKNOWN_SHAPE
   defp string_to_atom(nil, :color), do: :UNKNOWN_COLOR
-  defp string_to_atom(string, _), do: string |> String.upcase |> String.to_atom
+  defp string_to_atom(string, _), do: string |> String.to_atom()
 
   defp atom_to_string(nil), do: nil
   defp atom_to_string(:UNKNOWN_SHAPE), do: nil
   defp atom_to_string(:UNKNOWN_COLOR), do: nil
-  defp atom_to_string(atom), do: atom |> Atom.to_string |> String.downcase
+  defp atom_to_string(atom), do: atom |> Atom.to_string() |> String.upcase()
 
-  defp parse_string(<<>>),   do: nil
+  defp parse_string(<<>>), do: nil
   defp parse_string(string), do: string
 
   defp time() do
-    milliseconds = DateTime.utc_now()
+    DateTime.utc_now()
     |> DateTime.to_unix(:millisecond)
-
-    milliseconds / 1000
+    |> Kernel./(1000)
   end
 end

--- a/services/interop-proxy/lib/interop_proxy/session.ex
+++ b/services/interop-proxy/lib/interop_proxy/session.ex
@@ -18,23 +18,28 @@ defmodule InteropProxy.Session do
   send an `:ok` message when we've connected successfully.
   """
   def start_link(opts) do
-    url      = Keyword.fetch! opts, :url
-    username = Keyword.fetch! opts, :username
-    password = Keyword.fetch! opts, :password
+    url        = Keyword.fetch! opts, :url
+    username   = Keyword.fetch! opts, :username
+    password   = Keyword.fetch! opts, :password
+    mission_id = Keyword.fetch! opts, :mission_id
 
     resp = Keyword.get opts, :respond_to, nil
 
-    other_opts = Keyword.drop opts, [:url, :username, :password, :respond_to]
+    other_opts = Keyword.drop opts, [:url, :username, :password, :mission_id,
+                                     :respond_to]
 
     {^url, cookie} = do_login url, username, password
 
     if resp !== nil, do: send resp, :ok
 
     {:ok, pid} = Agent.start_link fn -> %{
-      url: url, cookie: cookie, username: username, password: password
+      url: url, cookie: cookie, username: username, password: password,
+      mission_id: mission_id
     } end, other_opts
 
-    spawn_link fn -> monitor_cookie pid, url, username, password end
+    spawn_link fn ->
+      monitor_cookie pid, url, username, password, mission_id
+    end
 
     {:ok, pid}
   end
@@ -54,10 +59,10 @@ defmodule InteropProxy.Session do
 
   # Keep checking if the cookie is still valid, if it's not, make a
   # new one for the session.
-  defp monitor_cookie(session, url, username, password) do
+  defp monitor_cookie(session, url, username, password, mission_id) do
     Process.sleep 5000
 
-    case Request.get_obstacles url, cookie(session) do
+    case Request.get_mission url, cookie(session), mission_id do
       {:error, :forbidden} ->
         {^url, cookie} = do_login url, username, password
         Agent.update session, &Map.put(&1, :cookie, cookie)
@@ -65,7 +70,7 @@ defmodule InteropProxy.Session do
         nil
     end
 
-    monitor_cookie session, url, username, password
+    monitor_cookie session, url, username, password, mission_id
   end
 
   @doc """
@@ -80,5 +85,12 @@ defmodule InteropProxy.Session do
   """
   def cookie(session \\ __MODULE__) do
     Agent.get session, &Map.get(&1, :cookie)
+  end
+
+  @doc """
+  Mission id to fetch.
+  """
+  def mission_id(session \\ __MODULE__) do
+    Agent.get session, &Map.get(&1, :mission_id)
   end
 end

--- a/services/interop-proxy/lib/interop_proxy_web/controllers/mission_controller.ex
+++ b/services/interop-proxy/lib/interop_proxy_web/controllers/mission_controller.ex
@@ -2,6 +2,6 @@ defmodule InteropProxyWeb.MissionController do
   use InteropProxyWeb, :controller
 
   def index(conn, _params) do
-    send_message conn, InteropProxy.get_active_mission
+    send_message conn, InteropProxy.get_mission
   end
 end

--- a/services/interop-proxy/priv/flasked_env.exs
+++ b/services/interop-proxy/priv/flasked_env.exs
@@ -2,6 +2,7 @@
   interop_proxy: %{
     url: {:flasked, :INTEROP_URL, :string, "0.0.0.0:8080"},
     username: {:flasked, :USERNAME, :string, "testuser"},
-    password: {:flasked, :PASSWORD, :string, "testpass"}
+    password: {:flasked, :PASSWORD, :string, "testpass"},
+    mission_id: {:flasked, :MISSION_ID, :integer, 1}
   }
 }

--- a/services/interop-proxy/test.sh
+++ b/services/interop-proxy/test.sh
@@ -16,7 +16,7 @@ start_interop_server() {
 
     docker run -itd --rm --net=interop-proxy-test-net --ip=172.37.0.2 \
             -p 8081:80 --name interop-proxy-test \
-            uavaustin/interop-server:2018.12 \
+            uavaustin/interop-server:2019.05 \
             > /dev/null
 
     if [ "$?" -ne 0 ]; then

--- a/services/interop-proxy/test/interop_proxy/session_test.exs
+++ b/services/interop-proxy/test/interop_proxy/session_test.exs
@@ -5,11 +5,12 @@ defmodule InteropProxy.SessionTest do
   alias InteropProxy.Session
   alias InteropProxy.TestHelper
 
-  import TestHelper, only: [url: 0, username: 0, password: 0]
+  import TestHelper, only: [url: 0, username: 0, password: 0, mission_id: 0]
 
   test "after starting a session, the cookie can be used for more requests" do
     {:ok, session} = Session.start_link url: url(), username: username(),
-                                        password: password()
+                                        password: password(),
+                                        mission_id: mission_id()
 
     s_url    = session |> Session.url
     s_cookie = session |> Session.cookie
@@ -17,12 +18,13 @@ defmodule InteropProxy.SessionTest do
     assert is_binary(s_url)
     assert is_binary(s_cookie)
 
-    {:ok, odlcs} = Request.get_odlcs s_url, s_cookie
+    {:ok, odlcs} = Request.get_odlcs s_url, s_cookie, mission_id()
     start_len = length odlcs
 
-    {:ok, _} = Request.post_odlc s_url, s_cookie, %{type: "off_axis"}
+    {:ok, _} = Request.post_odlc s_url, s_cookie, %{type: "OFF_AXIS"}, \
+                                 mission_id()
 
-    {:ok, odlcs} = Request.get_odlcs s_url, s_cookie
+    {:ok, odlcs} = Request.get_odlcs s_url, s_cookie, mission_id()
     end_len = length odlcs
 
     assert end_len === start_len + 1
@@ -30,7 +32,8 @@ defmodule InteropProxy.SessionTest do
 
   test "the session can be given a name" do
     {:ok, _} = Session.start_link url: url(), username: username(),
-                                  password: password(), name: :test
+                                  password: password(),
+                                  mission_id: mission_id(), name: :test
 
     s_url    = :test |> Session.url
     s_cookie = :test |> Session.cookie
@@ -39,7 +42,7 @@ defmodule InteropProxy.SessionTest do
     assert is_binary(s_cookie)
 
     {:ok, _} = Request.post_telemetry s_url, s_cookie, %{
-      latitude: 1, longitude: 2, altitude_msl: 3, uas_heading: 4
+      latitude: 1, longitude: 2, altitude: 3, heading: 4
     }
   end
 
@@ -50,8 +53,6 @@ defmodule InteropProxy.SessionTest do
     assert is_binary(s_url)
     assert is_binary(s_cookie)
 
-    {:ok, missions} = Request.get_missions s_url, s_cookie
-
-    assert length(missions) === 1
+    {:ok, _mission} = Request.get_mission s_url, s_cookie, mission_id()
   end
 end

--- a/services/interop-proxy/test/interop_proxy_test.exs
+++ b/services/interop-proxy/test/interop_proxy_test.exs
@@ -9,11 +9,11 @@ defmodule InteropProxyTest do
 
   import InteropProxy
 
-  test "get the active mission" do
-    mission = get_active_mission!()
+  test "get the mission" do
+    mission = get_mission!()
 
     assert mission.current_mission === true
-    assert is_float(mission.home_pos.lat)
+    assert is_float(mission.air_drop_pos.lat)
   end
 
   test "get stationary obstacles" do

--- a/services/interop-proxy/test/support/conn_case.ex
+++ b/services/interop-proxy/test/support/conn_case.ex
@@ -11,10 +11,10 @@ defmodule InteropProxyWeb.ConnCase do
 
       def protobuf_response(conn, status_code \\ 200, module) do
         content_type = get_resp_header conn, "content-type"
+        resp = response conn, status_code
 
         assert content_type === ["application/x-protobuf"]
-
-        conn |> response(status_code) |> module.decode
+        module.decode resp
       end
     end
   end

--- a/services/interop-proxy/test/test_helper.exs
+++ b/services/interop-proxy/test/test_helper.exs
@@ -1,9 +1,10 @@
 ExUnit.start()
 
 defmodule InteropProxy.TestHelper do
-  def url,      do: Application.get_env(:interop_proxy, :url)
-  def username, do: Application.get_env(:interop_proxy, :username)
-  def password, do: Application.get_env(:interop_proxy, :password)
+  def url,        do: Application.get_env(:interop_proxy, :url)
+  def username,   do: Application.get_env(:interop_proxy, :username)
+  def password,   do: Application.get_env(:interop_proxy, :password)
+  def mission_id, do: Application.get_env(:interop_proxy, :mission_id)
 
   def get_image(name) do
     Path.join([__DIR__, "data", name])

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -22,7 +22,7 @@ services:
         ipv4_address: 172.16.238.10
 
   interop-server:
-    image: uavaustin/interop-server:2018.12
+    image: uavaustin/interop-server:2019.05
     ports:
       - '8080:80'
     networks:


### PR DESCRIPTION
Updated Interop Proxy to work with the most recent Interop Server version. Note that because May is not complete yet, there could be changes after, as long as the Interop Proxy still works with the final May release of the Interop Server, the `uavaustin/interop-server:2019.05` tag will be updated.

The Interop Server saw changes to a several things:

- Requests are defined by a protobuf schema (still JSON though)
  - In the process some fields were removed (like home position) or renamed.
  - Enum fields need capital letters for the Python protobuf JSON parsing.
  - Since default values can be left off in protobufs, the sanitize functions needed to account for default values just in case.
- Obstacles are now in the mission instead of their own endpoint.
- Mission ID is now required, for now this is treated just like a username and password, so the API did not have to change for this.
  - The mission ID is also required for submitting oldcs as well.
  - When you fetch all oldcs it only returns those with the  mission ID set as well.

The API for Interop Proxy didn't change, except for the fact that the home position is gone from the mission. In the future, the obstacles could be merged into the mission message, like how it was done on the Interop Server side, but this PR keeps API changes at a minimum before the 2019 competition for integrating upcoming services.

Couple misc. changes also thrown in when working on the test cases. Reformatted the `sanitize.ex` file a little while also making edits to it.