### PR TITLE
Fix concurrency in imagery store

### DIFF
--- a/services/imagery/src/image-store.js
+++ b/services/imagery/src/image-store.js
@@ -66,7 +66,7 @@ export default class ImageStore extends EventEmitter {
         return db;
       },
       destroy: (db) => db.close()
-    }, { max: 5, min: 0 });
+    }, { max: 1, min: 0 });
 
     await this._withDb(async (db) => {
       await db.run('CREATE TABLE IF NOT EXISTS ' +

--- a/services/imagery/test/image-store.test.js
+++ b/services/imagery/test/image-store.test.js
@@ -145,3 +145,28 @@ test('image store gets latest ID', async () => {
 
   expect(await imageStore.getLatestId()).toEqual(latestId);
 });
+
+test('image store works concurrently', async () => {
+  const imageStore = new ImageStore(true);
+  await imageStore.setup();
+
+  await Promise.all([
+    imageStore.addImage(
+      shapes[0], imagery.Image.create({ time: 4 })
+    ),
+    imageStore.addImage(
+      shapes[1], imagery.Image.create({ time: 5 })
+    ),
+    imageStore.addImage(
+      shapes[2], imagery.Image.create({ time: 6 })
+    ),
+    imageStore.addImage(
+      shapes[0], imagery.Image.create({ time: 7 })
+    ),
+    imageStore.addImage(
+      shapes[1], imagery.Image.create({ time: 8 })
+    )
+  ]);
+
+  expect(await imageStore.getCount()).toEqual(5);
+});


### PR DESCRIPTION
Apparently, connection pools in SQLite are still too dumb to synchronize properly without triggering SQLITE_TIMEOUT, so I just decided to limit the connection pool to 1 to force mutual exclusion. However, I may have accidentally discovered a deadlock condition, given that the connection pool caused a timeout. I hope this is not the case.

Even with and without this fix, the tests for everything - not just the store - are failing once in a blue moon, which doesn't seem to be a good sign. What's worse is that the errors do not point to anything in particular - for instance, one error was about rolling back a transaction while a transaction was not underway. I checked the code path and there isn't a path where this could ever happen. Another error was a Z CAM E1 backend test saying that a dummy function was called twice when it should have been called three times. These are some very peculiar synchronization problems.