### PR TITLE
Allow accept header to be set to protobuf in Interop Proxy

### DIFF
--- a/services/interop-proxy/Dockerfile
+++ b/services/interop-proxy/Dockerfile
@@ -18,8 +18,9 @@ RUN mix deps.get && mix deps.compile
 COPY interop-proxy .
 COPY common/messages lib/messages
 
-# Make a release so we can copy it later.
-RUN mix release
+# Make a release so we can copy it later. (Cleaning mime since we
+# have the custom protobuf mime type.)
+RUN mix compile && mix deps.clean mime --build && mix release
 
 # Moving the archive to the top directory so it can be accessed
 # easily below.

--- a/services/interop-proxy/config/config.exs
+++ b/services/interop-proxy/config/config.exs
@@ -9,4 +9,8 @@ config :interop_proxy, InteropProxyWeb.Endpoint,
   render_errors: [view: InteropProxyWeb.ErrorView, accepts: ~w(json)],
   pubsub: [name: InteropProxy.PubSub, adapter: Phoenix.PubSub.PG2]
 
+config :mime, :types, %{
+  "application/x-protobuf" => ["protobuf"]
+}
+
 import_config "#{Mix.env}.exs"

--- a/services/interop-proxy/lib/interop_proxy_web/router.ex
+++ b/services/interop-proxy/lib/interop_proxy_web/router.ex
@@ -2,7 +2,7 @@ defmodule InteropProxyWeb.Router do
   use InteropProxyWeb, :router
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug :accepts, ["protobuf", "json"]
   end
 
   scope "/api", InteropProxyWeb do


### PR DESCRIPTION
Phoenix was configured to only allow JSON to be specified, and this adds a custom MIME type to make sure we can specify protobuf as well without assuming it as the default value.