### PR TITLE
Update all containers to Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,19 @@ jobs:
     - stage: test
       env: SERVICE_TEST=telemetry
       language: node_js
-      node_js: '8'
+      node_js: '10'
     - env: SERVICE_TEST=interop-proxy
       language: elixir
       elixir: '1.6'
     - env: SERVICE_TEST=pong
       language: node_js
-      node_js: '8'
+      node_js: '10'
     - env: SERVICE_TEST=forward-interop
       language: node_js
-      node_js: '8'
+      node_js: '10'
     - env: SERVICE_TEST=imagery
       language: node_js
-      node_js: '8'
+      node_js: '10'
     - env: SERVICE_TEST=image-rec-master
       language: python
       python: '3.7'

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=node:8-slim
+ARG BASE=node:10-slim
 
 # Compile our js source
 FROM ${BASE} AS builder

--- a/services/forward-interop/Dockerfile
+++ b/services/forward-interop/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 # Compile our js source.
 FROM ${BASE} AS builder

--- a/services/forward-interop/Dockerfile.test
+++ b/services/forward-interop/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 FROM ${BASE}
 

--- a/services/imagery/Dockerfile
+++ b/services/imagery/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 # Compile our js source.
 FROM ${BASE} AS builder

--- a/services/imagery/Dockerfile.test
+++ b/services/imagery/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 FROM ${BASE}
 

--- a/services/pong/Dockerfile
+++ b/services/pong/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 # Compile our js source.
 FROM ${BASE} AS builder

--- a/services/pong/Dockerfile.test
+++ b/services/pong/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 FROM ${BASE}
 

--- a/services/telemetry/Dockerfile
+++ b/services/telemetry/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 # Compile our js source.
 FROM ${BASE} AS builder

--- a/services/telemetry/Dockerfile.test
+++ b/services/telemetry/Dockerfile.test
@@ -1,4 +1,4 @@
-ARG BASE=node:8-alpine
+ARG BASE=node:10-alpine
 
 FROM ${BASE}
 


### PR DESCRIPTION
Node 8 will EOL at the end of the year. No breakages are expected in moving to Node 10, but we'll let the CI decide whether that really is true.