### PR TITLE
Z CAM E1 fixes

### DIFF
--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -78,10 +78,9 @@ export default class ZCamE1Backend extends CameraBaseBackend {
     await this._setParam(`/datetime?date=${date}&time=${time}`);
 
     // Load the configuration.
-    configuration.forEach(async pair => {
-      const [key, val] = pair;
-      await this._makeReq(key, val);
-    });
+    await Promise.all(
+      configuration.map(([key, val]) => this._setParam(key, val))
+    );
 
     const temperature = await this._makeReq('/ctrl/temperature');
     logger.debug(`Temperature: ${temperature['msg']}`);

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -78,9 +78,9 @@ export default class ZCamE1Backend extends CameraBaseBackend {
     await this._setParam(`/datetime?date=${date}&time=${time}`);
 
     // Load the configuration.
-    await Promise.all(
-      configuration.map(([key, val]) => this._setParam(key, val))
-    );
+    for (const [key, val] of configuration) {
+      await this._setParam(key, val);
+    }
 
     const temperature = await this._makeReq('/ctrl/temperature');
     logger.debug(`Temperature: ${temperature['msg']}`);

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -15,13 +15,73 @@ export default class ZCamE1Backend extends CameraBaseBackend {
     this._cameraUrl = cameraUrl;
   }
 
-  /** Get a session on the camera. */
+  /** Get a session on the camera and configure the camera. */
   async acquire() {
     await this._makeReq('/ctrl/session');
+
+    // Set the date
+    const datetime = new Date();
+    const time  = datetime.toTimeString().split(' ')[0];
+    const year  = `${datetime.getFullYear()}`.padStart(4, '0'); // no left-pad
+    const month = `${datetime.getMonth()}`.padStart(2, '0');
+    const day   = `${datetime.getDate()}`.padStart(2, '0');
+    const date  = `${year}-${month}-${day}`;
+    await this._setParam(`/datetime?date=${date}&time=${datetime}`);
+
+    await this._makeReq('/ctrl/mode?action=to_cap'); // Put us in capture mode
+    await this._setParam('drive_mode', 'single');  // Single shot drive mode
+    await this._setParam('photosize', '16M');      // 16M
+    await this._setParam('wb', 'Auto');            // Auto WB (White Balance)
+    await this._setParam('iso', 'Auto');           // Auto ISO
+    await this._setParam('sharpness', 'Normal');   // Normal Sharpness
+    await this._setParam('contrast', '64');        // 64/256 for Contrast
+    await this._setParam('saturation', '64');      // 64/256 for Saturation
+    await this._setParam('brightness', '0');       // Brightness: 0 [-256, 256]
+    await this._setParam('meter_mode', 'Average'); // Average for Meter Mode
+    await this._setParam('ev', '0');               // EV: 0 (to start) [-96, 96]
+    await this._setParam('lcd', 'Off')             // LCD off (save some power)
+    await this._setParam('rotation', 'Normal')     // We're not upside down!
+    await this._setParam('focus', 'AF')            // Enable Autofocus
+    await this._setParam('af_mode', 'Normal')      // Normal Autofocus mode
+    await this._setParam('photo_q', 'S.Fine');     // Photo Quality
+    await this._setParam('led', 'On');             // LEDs on!
+    await this._setParam('max_exp', 'Auto');       // Auto Exposure Time
+    await this._setParam('shutter_angle', 'Auto'); // Shouldn't matter
+    // Skipping "mwb"; this should have an invalid negative value when queried.
+    await this._setParam('shutter_spd', 'Auto');   // Auto Shutter Speed
+    await this._setParam('caf_range', 'Auto');     // Auto Continuous AF Range
+    await this._setParam('caf_sens', 'Middle');    // Middle CAF Sensitivity
+    await this._setParam('lut', 'sRGB');           // sRGB lookup
+    await this._setParam('dewarp', 'On');          // Distortion Correction: On
+    await this._setParam('vignette', 'Off');       // Vignette Correction: Off
+    await this._setParam('noise_reduction', 'NormalNoise');
+    await this._setParam('lcd_backlight', '25');   // Dim the screen
+    await this._setParam('oled', 'Off');           // Turn off the OLED Screen
+    await this._setParam('shoot_mode', 'Program AE');
+    await this._setParam('liveview_audio', 'On');
+    await this._setParam('max_iso', '6400');       // Max ISO to absolute max
+    await this._setParam('auto_off', '0');         // Disable auto-off
+    await this._setParam('auto_off_lcd', '30');    // 30s LCD timeout
+    await this._setParam('caf', '1');              // Continuous AF: On
+    await this._setParam('grid_display', '0');     // No grids!
+    await this._setParam('level_correction', '0'); // Level Correction: Off
+
+    // Query:
+    //  - the battery level
+    //  - the temperature
+    //  - number of remaining shots
+    //  - aperture (iris)
+    //  - last file name
+    //  - camera rot
+    //  - file number
+    // and say something.
   }
 
-  /** Capture an image, download it, and remove it. */
+  /** Focus, capture an image, download it, and remove it. */
   async capture() {
+    // No explicit focus position; figure out the area automatically.
+    await this._makeReq('/ctrl/af');
+
     const filename = (await this._makeReq('/ctrl/still?action=single')).msg;
     const photo = await this._makeReq(filename, true);
     await this._makeReq(filename + '?act=rm');
@@ -53,5 +113,9 @@ export default class ZCamE1Backend extends CameraBaseBackend {
         return body;
       }
     }
+  }
+
+  async _setParam(param, value) {
+    await this._makeReq(`/ctrl/set?${param}=${value}`)
   }
 }

--- a/services/imagery/src/backends/z-cam-e1-backend.js
+++ b/services/imagery/src/backends/z-cam-e1-backend.js
@@ -1,6 +1,47 @@
 import request from 'superagent';
 
+import logger from '../common/logger';
+
 import CameraBaseBackend from './camera-base-backend';
+
+const configuration = [
+  ['drive_mode', 'single'],           // Single shot drive mode
+  ['photosize', '16M'],               // 16M
+  ['wb', 'Auto'],                     // Auto WB (White Balance)
+  ['iso', 'Auto'],                    // Auto ISO
+  ['sharpness', 'Normal'],            // Normal Sharpness
+  ['contrast', '64'],                 // 64/256 for Contrast
+  ['saturation', '64'],               // 64/256 for Saturation
+  ['brightness', '0'],                // Brightness: 0 [-256, 256]
+  ['meter_mode', 'Average'],          // Average for Meter Mode
+  ['ev', '0'],                        // EV: 0 (to start) [-96, 96]
+  ['lcd', 'Off'],                     // LCD off (save some power)
+  ['rotation', 'Normal'],             // We're not upside down!
+  ['focus', 'AF'],                    // Enable Autofocus
+  ['af_mode', 'Normal'],              // Normal Autofocus mode
+  ['photo_q', 'S.Fine'],              // Photo Quality
+  ['led', 'On'],                      // LEDs on!
+  ['max_exp', 'Auto'],                // Auto Exposure Time
+  ['shutter_angle', 'Auto'],          // Shouldn't matter
+  // Skipping "mwb"; this should have an invalid value when queried.
+  ['shutter_spd', 'Auto'],            // Auto Shutter Speed
+  ['caf_range', 'Auto'],              // Auto Continuous AF Range
+  ['caf_sens', 'Middle'],             // Middle CAF Sensitivity
+  ['lut', 'sRGB'],                    // sRGB lookup
+  ['dewarp', 'On'],                   // Distortion Correction: On
+  ['vignette', 'Off'],                // Vignette Correction: Off
+  ['noise_reduction', 'NormalNoise'], // Default Noise Reduction
+  ['lcd_backlight', '25'],            // Dim the screen
+  ['oled', 'Off'],                    // Turn off the OLED Screen
+  ['shoot_mode', 'Program AE'],       // Auto Mode, roughly.
+  ['liveview_audio', 'On'],           // Listen to the wind howling
+  ['max_iso', '6400'],                // Max ISO to absolute max
+  ['auto_off', '0'],                  // Disable auto-off
+  ['auto_off_lcd', '30'],             // 30s LCD timeout
+  ['caf', '1'],                       // Continuous AF: On
+  ['grid_display', '0'],              // No grids!
+  ['level_correction', '0'],          // Level Correction: Off
+];
 
 export default class ZCamE1Backend extends CameraBaseBackend {
   /**
@@ -19,62 +60,37 @@ export default class ZCamE1Backend extends CameraBaseBackend {
   async acquire() {
     await this._makeReq('/ctrl/session');
 
-    // Set the date
+    // Set the date. (no left-pad)
     const datetime = new Date();
     const time  = datetime.toTimeString().split(' ')[0];
-    const year  = `${datetime.getFullYear()}`.padStart(4, '0'); // no left-pad
+    const year  = `${datetime.getFullYear()}`.padStart(4, '0');
     const month = `${datetime.getMonth()}`.padStart(2, '0');
     const day   = `${datetime.getDate()}`.padStart(2, '0');
     const date  = `${year}-${month}-${day}`;
-    await this._setParam(`/datetime?date=${date}&time=${datetime}`);
+    await this._setParam(`/datetime?date=${date}&time=${time}`);
 
-    await this._makeReq('/ctrl/mode?action=to_cap'); // Put us in capture mode
-    await this._setParam('drive_mode', 'single');  // Single shot drive mode
-    await this._setParam('photosize', '16M');      // 16M
-    await this._setParam('wb', 'Auto');            // Auto WB (White Balance)
-    await this._setParam('iso', 'Auto');           // Auto ISO
-    await this._setParam('sharpness', 'Normal');   // Normal Sharpness
-    await this._setParam('contrast', '64');        // 64/256 for Contrast
-    await this._setParam('saturation', '64');      // 64/256 for Saturation
-    await this._setParam('brightness', '0');       // Brightness: 0 [-256, 256]
-    await this._setParam('meter_mode', 'Average'); // Average for Meter Mode
-    await this._setParam('ev', '0');               // EV: 0 (to start) [-96, 96]
-    await this._setParam('lcd', 'Off')             // LCD off (save some power)
-    await this._setParam('rotation', 'Normal')     // We're not upside down!
-    await this._setParam('focus', 'AF')            // Enable Autofocus
-    await this._setParam('af_mode', 'Normal')      // Normal Autofocus mode
-    await this._setParam('photo_q', 'S.Fine');     // Photo Quality
-    await this._setParam('led', 'On');             // LEDs on!
-    await this._setParam('max_exp', 'Auto');       // Auto Exposure Time
-    await this._setParam('shutter_angle', 'Auto'); // Shouldn't matter
-    // Skipping "mwb"; this should have an invalid negative value when queried.
-    await this._setParam('shutter_spd', 'Auto');   // Auto Shutter Speed
-    await this._setParam('caf_range', 'Auto');     // Auto Continuous AF Range
-    await this._setParam('caf_sens', 'Middle');    // Middle CAF Sensitivity
-    await this._setParam('lut', 'sRGB');           // sRGB lookup
-    await this._setParam('dewarp', 'On');          // Distortion Correction: On
-    await this._setParam('vignette', 'Off');       // Vignette Correction: Off
-    await this._setParam('noise_reduction', 'NormalNoise');
-    await this._setParam('lcd_backlight', '25');   // Dim the screen
-    await this._setParam('oled', 'Off');           // Turn off the OLED Screen
-    await this._setParam('shoot_mode', 'Program AE');
-    await this._setParam('liveview_audio', 'On');
-    await this._setParam('max_iso', '6400');       // Max ISO to absolute max
-    await this._setParam('auto_off', '0');         // Disable auto-off
-    await this._setParam('auto_off_lcd', '30');    // 30s LCD timeout
-    await this._setParam('caf', '1');              // Continuous AF: On
-    await this._setParam('grid_display', '0');     // No grids!
-    await this._setParam('level_correction', '0'); // Level Correction: Off
+    // Put us in capture mode:.
+    await this._makeReq('/ctrl/mode?action=to_cap');
 
-    // Query:
-    //  - the battery level
-    //  - the temperature
-    //  - number of remaining shots
-    //  - aperture (iris)
-    //  - last file name
-    //  - camera rot
-    //  - file number
-    // and say something.
+    // Load the configuration.
+    configuration.forEach(async pair => {
+      const [key, val] = pair;
+      await this._makeReq(key, val);
+    });
+
+    const temperature = await this._makeReq('/ctrl/temperature');
+    logger.debug(`Temperature: ${temperature['msg']}`);
+
+    const remaining_shots = await this._makeReq('/ctrl/still?action=remain');
+    logger.debug(`Remaining Shots: ${remaining_shots['msg']}`);
+
+    logger.debug(`Battery Level: ${await this._getParam('battery')}`);
+    logger.debug(`Aperture: f/${await this._getParam('iris')}`);
+    logger.debug(`Last File Name: ${await this._getParam('last_file_name')}`);
+    logger.debug(`Camera Rotation: ${await this._getParam('camera_rot')}`);
+    logger.debug(`File Number: ${await this._getParam('file_number')}`);
+
+    logger.debug('📷 ready.');
   }
 
   /** Focus, capture an image, download it, and remove it. */
@@ -116,6 +132,11 @@ export default class ZCamE1Backend extends CameraBaseBackend {
   }
 
   async _setParam(param, value) {
-    await this._makeReq(`/ctrl/set?${param}=${value}`)
+    await this._makeReq(`/ctrl/set?${param}=${value}`);
+  }
+
+  async _getParam(param) {
+    const resp = await this._makeReq(`/ctrl/get?k=${param}`);
+    return resp['value'];
   }
 }

--- a/services/imagery/src/service.js
+++ b/services/imagery/src/service.js
@@ -32,6 +32,7 @@ export default class Service {
    * @param {string} [options.telemetryHost]
    * @param {string} [options.telemetryPort]
    * @param {number} [options.captureInterval] - milliseconds
+   * @param {bool}   [options.extendedConfiguration]
    */
   constructor(options) {
     const backends = ['gphoto2', 'z-cam-e1', 'file', 'sync'];
@@ -60,6 +61,10 @@ export default class Service {
     this._captureInterval = options.captureInterval;
 
     this._maxImages = options.maxImages;
+
+    // If unset, assume true.
+    this._extendedConfiguration =
+        (options.extendedConfiguration === false) ? false : true;
   }
 
   /** Start the service. */
@@ -81,7 +86,7 @@ export default class Service {
     case 'z-cam-e1':
       this._backend = new ZCamE1Backend(
         this._imageStore, this._captureInterval, this._cameraUrl,
-        this._telemetryUrl
+        this._telemetryUrl, this._extendedConfiguration
       );
       break;
     case 'file':

--- a/services/imagery/test/backends/z-cam-e1-backend.test.js
+++ b/services/imagery/test/backends/z-cam-e1-backend.test.js
@@ -46,7 +46,7 @@ test('capture images with telemetry when available', async () => {
       code: 0, desc: '', msg: '/DCIM/100MEDIA/EYED6392.JPG'
     }))
     .get('/DCIM/100MEDIA/EYED6392.JPG')
-    .reply(200, image, JSON.stringify({ 'content-type': 'image/jpeg' }))
+    .reply(200, image, { 'content-type': 'image/jpeg' })
     .get('/DCIM/100MEDIA/EYED6392.JPG?act=rm')
     .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
     .get('/ctrl/session?action=quit')

--- a/services/imagery/test/service.test.js
+++ b/services/imagery/test/service.test.js
@@ -13,6 +13,8 @@ gphoto2.GPhoto2 = jest.fn(() => {
 nock('http://camera:1234')
   .get('/ctrl/session')
   .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
+  .get('/ctrl/mode?action=to_cap')
+  .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }))
   .get('/ctrl/session?action=quit')
   .reply(200, JSON.stringify({ code: 0, desc: '', msg: '' }));
 
@@ -21,7 +23,8 @@ const options = [
   { port: 8081, backend: 'gphoto2', telemetryHost: 'telemetry',
     telemetryPort: 5000, captureInterval: 4000 },
   { port: 8081, backend: 'z-cam-e1', cameraHost: 'camera', cameraPort: 1234,
-    telemetryHost: 'telemetry', telemetryPort: 5000, captureInterval: 4000 },
+    telemetryHost: 'telemetry', telemetryPort: 5000, captureInterval: 4000,
+    extendedConfiguration: false },
   { port: 8081, backend: 'file' },
   { port: 8081, backend: 'sync', imagerySyncHost: 'imagery',
     imagerySyncPort: 8082 }


### PR DESCRIPTION
These were unmerged changes to the Z CAM E1 imagery backend. I don't think the changes made it to competition.

I'm a little skeptical of the "extended configuration" part. That should probably be moved over to a separate method and be called `reset` or `reconfigure`. The main idea is that it places the camera's capture settings in a predictable state.