### PR TITLE
Upgrade from Node 8 to 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,19 +23,19 @@ jobs:
     - stage: test
       env: SERVICE_TEST=telemetry
       language: node_js
-      node_js: '8'
+      node_js: '12'
     - env: SERVICE_TEST=interop-proxy
       language: elixir
       elixir: '1.6'
     - env: SERVICE_TEST=pong
       language: node_js
-      node_js: '8'
+      node_js: '12'
     - env: SERVICE_TEST=forward-interop
       language: node_js
-      node_js: '8'
+      node_js: '12'
     - env: SERVICE_TEST=imagery
       language: node_js
-      node_js: '8'
+      node_js: '10'
     - env: SERVICE_TEST=image-rec-master
       language: python
       python: '3.7'

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our js source
-FROM node:8-slim AS builder
+FROM node:12-slim AS builder
 
 WORKDIR /builder
 
@@ -17,7 +17,7 @@ COPY dashboard .
 RUN npm run build
 
 # Making the actual image now
-FROM node:8-slim
+FROM node:12-slim
 
 WORKDIR /app
 

--- a/services/forward-interop/Dockerfile
+++ b/services/forward-interop/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our js source.
-FROM node:8-alpine AS builder
+FROM node:12-alpine AS builder
 
 WORKDIR /builder
 
@@ -20,7 +20,7 @@ COPY forward-interop .
 RUN npm run build
 
 # Make the actual image now.
-FROM node:8-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/services/forward-interop/Dockerfile.test
+++ b/services/forward-interop/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 ENV NODE_ENV=test
 

--- a/services/imagery/Dockerfile
+++ b/services/imagery/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our js source.
-FROM node:8-alpine AS builder
+FROM node:10-alpine AS builder
 
 WORKDIR /builder
 
@@ -29,7 +29,7 @@ COPY imagery .
 RUN npm run build
 
 # Make the actual image now.
-FROM node:8-alpine
+FROM node:10-alpine
 
 WORKDIR /app
 

--- a/services/imagery/Dockerfile.test
+++ b/services/imagery/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 ENV NODE_ENV=test
 

--- a/services/pong/Dockerfile
+++ b/services/pong/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our js source.
-FROM node:8-alpine AS builder
+FROM node:12-alpine AS builder
 
 WORKDIR /builder
 
@@ -25,7 +25,7 @@ COPY pong .
 RUN npm run build
 
 # Make the actual image now.
-FROM node:8-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/services/pong/Dockerfile.test
+++ b/services/pong/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 ENV NODE_ENV=test
 

--- a/services/telemetry/Dockerfile
+++ b/services/telemetry/Dockerfile
@@ -1,5 +1,5 @@
 # Compile our js source.
-FROM node:8-alpine AS builder
+FROM node:12-alpine AS builder
 
 WORKDIR /builder
 
@@ -20,7 +20,7 @@ COPY telemetry .
 RUN npm run build
 
 # Make the actual image now.
-FROM node:8-alpine
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/services/telemetry/Dockerfile.test
+++ b/services/telemetry/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 ENV NODE_ENV=test
 


### PR DESCRIPTION
Imagery had to be held back to Node 10, as the gphoto2 bindings do not compile under Node 12:

../src/camera.cc: In static member function 'static void GPCamera::Initialize(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE)':
../src/camera.cc:43:38: error: no matching function for call to 'v8::FunctionTemplate::GetFunction()'
   43 |   constructor.Reset(tpl->GetFunction());