### PR TITLE
Fix interop-proxy authorization

### DIFF
--- a/services/interop-proxy/README.md
+++ b/services/interop-proxy/README.md
@@ -8,15 +8,15 @@ with the server.
 
 ## Running the Image
 
-When running the image, make sure to pass in the `INTEROP_URL`, `USERNAME`,
-`PASSWORD`, `MISSION_ID` envrionment variables. They default to `0.0.0.0:8080`,
+When running the image, make sure to pass in the `INTEROP_URL`, `INTEROP_USERNAME`,
+`INTEROP_PASSWORD`, `MISSION_ID` envrionment variables. They default to `0.0.0.0:8080`,
 `testuser`, `testpass`, and `1` respectively.
 
 ```
 $ docker run -it -p 8000:8000 \
     -e INTEROP_URL="192.168.0.5:8080" \
-    -e USERNAME="someuser" \
-    -e PASSWORD="somepass" \
+    -e INTEROP_USERNAME="someuser" \
+    -e INTEROP_PASSWORD="somepass" \
     -e MISSION_ID="1" \
     uavaustin/interop-proxy
 ```

--- a/services/interop-proxy/lib/interop_proxy/session.ex
+++ b/services/interop-proxy/lib/interop_proxy/session.ex
@@ -49,10 +49,19 @@ defmodule InteropProxy.Session do
     case Request.login url, username, password do
       {:ok, _, cookie} ->
         {url, cookie}
+      {:error, {:message, status_code, body}} ->
+        IO.puts "An error occurred while attempting to connect:"
+        IO.puts "HTTP status code: #{status_code}"
+        IO.puts "Username: #{username}"
+        IO.puts "Password: #{password}"
+        IO.puts "--- Error Response Body ---"
+        IO.puts body
+        IO.puts "---------------------------"
+        Process.sleep 3000
+        do_login url, username, password
       _ ->
         IO.puts "Interop server could not be reached... trying again."
         Process.sleep 500
-
         do_login url, username, password
     end
   end

--- a/services/interop-proxy/priv/flasked_env.exs
+++ b/services/interop-proxy/priv/flasked_env.exs
@@ -1,8 +1,8 @@
 %{
   interop_proxy: %{
     url: {:flasked, :INTEROP_URL, :string, "0.0.0.0:8080"},
-    username: {:flasked, :USERNAME, :string, "testuser"},
-    password: {:flasked, :PASSWORD, :string, "testpass"},
+    username: {:flasked, :INTEROP_USERNAME, :string, "testuser"},
+    password: {:flasked, :INTEROP_PASSWORD, :string, "testpass"},
     mission_id: {:flasked, :MISSION_ID, :integer, 1}
   }
 }


### PR DESCRIPTION
Fix issue where interop-proxy overloads a common environment variable, `USERNAME`. Replaces the old `USERNAME` and `PASSWORD` environment variables with `INTEROP_USERNAME` and `INTEROP_PASSWORD`.

Also adds a more detailed error message when failing on login.