### PR TITLE
Remove off-axis ODLC targets from interop-proxy tests

### DIFF
--- a/services/common/messages/interop.proto
+++ b/services/common/messages/interop.proto
@@ -102,7 +102,6 @@ message InteropTelem {
 message Odlc {
     enum Type {
         STANDARD = 0;
-        OFF_AXIS = 1;
         EMERGENT = 2;
     }
 

--- a/services/interop-proxy/test/interop_proxy/request_test.exs
+++ b/services/interop-proxy/test/interop_proxy/request_test.exs
@@ -89,7 +89,7 @@ defmodule InteropProxy.RequestTest do
     assert end_count === starting_count - 1
   end
 
-  test "add an off axis and emergent odlc" do
+  test "add a standard and emergent odlc" do
     {:ok, _, cookie} = Request.login url(), username(), password()
 
     # Getting the reference count (in case the interop server was not
@@ -97,9 +97,9 @@ defmodule InteropProxy.RequestTest do
     get_count = fn ->
       {:ok, all_odlc} = Request.get_odlcs url(), cookie, mission_id()
 
-      off_axis_count = Enum.count(all_odlc, fn
+      standard_count = Enum.count(all_odlc, fn
         %{
-          "type" => "OFF_AXIS", "latitude" => 12.345, "longitude" => 34.567
+          "type" => "STANDARD", "latitude" => 12.345, "longitude" => 34.567
         } -> true
         _ -> false
       end)
@@ -112,13 +112,13 @@ defmodule InteropProxy.RequestTest do
         _ -> false
       end)
 
-      {off_axis_count, emergent_count}
+      {standard_count, emergent_count}
     end
 
     {start_oa, start_e} = get_count.()
 
     {:ok, %{"id" => id_1}} = Request.post_odlc url(), cookie, %{
-      type: "OFF_AXIS", latitude: 12.345, longitude: 34.567
+      type: "STANDARD", latitude: 12.345, longitude: 34.567
     }, mission_id()
 
     image_2 = TestHelper.get_image "image-2.jpg"

--- a/services/interop-proxy/test/interop_proxy/session_test.exs
+++ b/services/interop-proxy/test/interop_proxy/session_test.exs
@@ -21,7 +21,7 @@ defmodule InteropProxy.SessionTest do
     {:ok, odlcs} = Request.get_odlcs s_url, s_cookie, mission_id()
     start_len = length odlcs
 
-    {:ok, _} = Request.post_odlc s_url, s_cookie, %{type: "OFF_AXIS"}, \
+    {:ok, _} = Request.post_odlc s_url, s_cookie, %{type: "STANDARD"}, \
                                  mission_id()
 
     {:ok, odlcs} = Request.get_odlcs s_url, s_cookie, mission_id()

--- a/services/interop-proxy/test/interop_proxy_test.exs
+++ b/services/interop-proxy/test/interop_proxy_test.exs
@@ -101,12 +101,12 @@ defmodule InteropProxyTest do
 
     # Posting a new odlc.
     %{id: id} = post_odlc! %Odlc{
-      type: :OFF_AXIS, shape: :SQUARE, background_color: :RED, image: image_1
+      type: :STANDARD, shape: :SQUARE, background_color: :RED, image: image_1
     }
 
     # Updating it.
     returned = put_odlc! id, %Odlc{
-      type: :OFF_AXIS, background_color: :BLUE, orientation: :SOUTH
+      type: :STANDARD, background_color: :BLUE, orientation: :SOUTH
     }
 
     # Since we're using structs, the default value of shape will be
@@ -119,7 +119,7 @@ defmodule InteropProxyTest do
     assert get_odlc!(id, image: true).image === image_1
 
     # Updating it with an image as well.
-    returned = put_odlc! id, %Odlc{type: :OFF_AXIS, image: image_2}
+    returned = put_odlc! id, %Odlc{type: :STANDARD, image: image_2}
 
     assert returned.shape === :UNKNOWN_SHAPE
     assert returned.background_color === :UNKNOWN_COLOR

--- a/services/interop-proxy/test/interop_proxy_web/controllers/odlc_controller_test.exs
+++ b/services/interop-proxy/test/interop_proxy_web/controllers/odlc_controller_test.exs
@@ -12,7 +12,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
       image_2 = TestHelper.get_image "image-2.jpg"
 
       odlc = post_odlc! %Odlc{
-        type: :OFF_AXIS,
+        type: :STANDARD,
         pos: %Position{lat: 60, lon: 50},
         image: image_2
       }
@@ -27,7 +27,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
 
       odlc = Enum.find response.list, &(&1.id === context.id)
 
-      assert odlc.type === :OFF_AXIS
+      assert odlc.type === :STANDARD
       assert odlc.pos.lat == 60
       assert odlc.pos.lon == 50
       assert odlc.image === <<>>
@@ -40,7 +40,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
 
       odlc = Enum.find response.list, &(&1.id === context.id)
 
-      assert odlc.type === :OFF_AXIS
+      assert odlc.type === :STANDARD
       assert odlc.pos.lat == 60
       assert odlc.pos.lon == 50
       assert odlc.image === context.image
@@ -54,7 +54,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
 
       odlc = Enum.find response["list"], &(&1["id"] === context.id)
 
-      assert odlc["type"] === "OFF_AXIS"
+      assert odlc["type"] === "STANDARD"
       assert odlc["pos"]["lat"] == 60
       assert odlc["pos"]["lon"] == 50
       assert odlc["image"] === <<>>
@@ -68,7 +68,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
 
       odlc = Enum.find response["list"], &(&1["id"] === context.id)
 
-      assert odlc["type"] === "OFF_AXIS"
+      assert odlc["type"] === "STANDARD"
       assert odlc["pos"]["lat"] == 60
       assert odlc["pos"]["lon"] == 50
       assert odlc["image"] === Base.encode64(context.image)
@@ -151,13 +151,13 @@ defmodule InteropProxyWeb.OdlcControllerTest do
       response = context.conn
       |> put_req_header("content-type", "application/x-protobuf")
       |> post(odlc_path(context.conn, :create), %Odlc{
-        type: :OFF_AXIS,
+        type: :STANDARD,
         shape: :RECTANGLE,
         pos: %Position{lat: -1, lon: 1}
       } |> Odlc.encode)
       |> protobuf_response(Odlc)
 
-      assert response.type === :OFF_AXIS
+      assert response.type === :STANDARD
       assert response.shape === :RECTANGLE
       assert response.pos.lat == -1
       assert response.pos.lon == 1
@@ -169,13 +169,13 @@ defmodule InteropProxyWeb.OdlcControllerTest do
       response = context.conn
       |> put_req_header("content-type", "application/x-protobuf")
       |> post(odlc_path(context.conn, :create), %Odlc{
-        type: :OFF_AXIS,
+        type: :STANDARD,
         shape: :TRAPEZOID,
         image: context.image
       } |> Odlc.encode)
       |> protobuf_response(Odlc)
 
-      assert response.type === :OFF_AXIS
+      assert response.type === :STANDARD
       assert response.shape === :TRAPEZOID
       assert response.image === <<>>
     end
@@ -185,13 +185,13 @@ defmodule InteropProxyWeb.OdlcControllerTest do
       |> put_req_header("accept", "application/json")
       |> put_req_header("content-type", "application/json")
       |> post(odlc_path(context.conn, :create), %{
-        type: "OFF_AXIS",
+        type: "STANDARD",
         shape: "RECTANGLE",
         pos: %{lat: -1, lon: 1}
       })
       |> json_response(200)
 
-      assert response["type"] === "OFF_AXIS"
+      assert response["type"] === "STANDARD"
       assert response["shape"] === "RECTANGLE"
       assert response["pos"]["lat"] == -1
       assert response["pos"]["lon"] == 1
@@ -204,13 +204,13 @@ defmodule InteropProxyWeb.OdlcControllerTest do
       |> put_req_header("accept", "application/json")
       |> put_req_header("content-type", "application/json")
       |> post(odlc_path(context.conn, :create), %{
-        type: "OFF_AXIS",
+        type: "STANDARD",
         shape: "TRAPEZOID",
         image: Base.encode64(context.image) 
       })
       |> json_response(200)
 
-      assert response["type"] === "OFF_AXIS"
+      assert response["type"] === "STANDARD"
       assert response["shape"] === "TRAPEZOID"
       assert response["image"] === <<>>
     end
@@ -300,7 +300,7 @@ defmodule InteropProxyWeb.OdlcControllerTest do
 
   describe "delete/2" do
     setup _context do
-      odlc_1 = post_odlc! %Odlc{type: :OFF_AXIS}
+      odlc_1 = post_odlc! %Odlc{type: :STANDARD}
       odlc_2 = post_odlc! %Odlc{type: :EMERGENT}
 
       {:ok, id_1: odlc_1.id, id_2: odlc_2.id}


### PR DESCRIPTION
Fixes 13 broken interop-proxy tests which used off-axis ODLC targets. Off-axis targets are now classified as standard targets. (Although it's important to note that the mission data still includes the position of an off-axis target.)